### PR TITLE
Raise NotImplementedError when forecasts disabled instead of returnin…

### DIFF
--- a/custom_components/google_weather/weather.py
+++ b/custom_components/google_weather/weather.py
@@ -269,9 +269,9 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
 
     async def async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast."""
-        # Return None if daily forecasts are disabled
+        # Raise NotImplementedError if daily forecasts are disabled
         if not (self._attr_supported_features & WeatherEntityFeature.FORECAST_DAILY):
-            return None
+            raise NotImplementedError("Daily forecasts are disabled for this weather entity")
 
         try:
             if not self.coordinator.data:
@@ -317,9 +317,9 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
 
     async def async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast."""
-        # Return None if hourly forecasts are disabled
+        # Raise NotImplementedError if hourly forecasts are disabled
         if not (self._attr_supported_features & WeatherEntityFeature.FORECAST_HOURLY):
-            return None
+            raise NotImplementedError("Hourly forecasts are disabled for this weather entity")
 
         try:
             if not self.coordinator.data:


### PR DESCRIPTION
…g None

Changed async_forecast_daily/hourly to raise NotImplementedError when forecasts are disabled, instead of returning None. This more clearly signals to the Home Assistant frontend that the forecast methods are not available/supported.

Per HA docs: "Only implement this method if WeatherEntityFeature.FORECAST_DAILY is set" While we can't conditionally remove methods in Python, raising NotImplementedError is the closest equivalent and should prevent the frontend from showing loading spinners.