### PR TITLE
Add detailed logging to prove forecast methods behavior

### DIFF
--- a/custom_components/google_weather/weather.py
+++ b/custom_components/google_weather/weather.py
@@ -269,8 +269,19 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
 
     async def async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast."""
+        _LOGGER.debug(
+            "async_forecast_daily called - supported_features: %s, FORECAST_DAILY enabled: %s",
+            self._attr_supported_features,
+            bool(self._attr_supported_features & WeatherEntityFeature.FORECAST_DAILY)
+        )
+
         # Raise NotImplementedError if daily forecasts are disabled
         if not (self._attr_supported_features & WeatherEntityFeature.FORECAST_DAILY):
+            _LOGGER.warning(
+                "async_forecast_daily called but FORECAST_DAILY is not enabled (supported_features=%s). "
+                "Raising NotImplementedError. This should not happen - the frontend should check supported_features first.",
+                self._attr_supported_features
+            )
             raise NotImplementedError("Daily forecasts are disabled for this weather entity")
 
         try:
@@ -317,8 +328,19 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
 
     async def async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast."""
+        _LOGGER.debug(
+            "async_forecast_hourly called - supported_features: %s, FORECAST_HOURLY enabled: %s",
+            self._attr_supported_features,
+            bool(self._attr_supported_features & WeatherEntityFeature.FORECAST_HOURLY)
+        )
+
         # Raise NotImplementedError if hourly forecasts are disabled
         if not (self._attr_supported_features & WeatherEntityFeature.FORECAST_HOURLY):
+            _LOGGER.warning(
+                "async_forecast_hourly called but FORECAST_HOURLY is not enabled (supported_features=%s). "
+                "Raising NotImplementedError. This should not happen - the frontend should check supported_features first.",
+                self._attr_supported_features
+            )
             raise NotImplementedError("Hourly forecasts are disabled for this weather entity")
 
         try:


### PR DESCRIPTION
Added comprehensive logging to async_forecast_daily/hourly methods:

- DEBUG log shows when method is called and supported_features value
- WARNING log if method called when feature not enabled (proves frontend bug)
- Logs show exact supported_features value and whether feature is enabled

This will prove in the logs whether:
1. The frontend is calling forecast methods despite supported_features=0
2. The methods are correctly raising NotImplementedError
3. What the actual supported_features value is at runtime

Example log output when forecasts disabled:
"async_forecast_daily called but FORECAST_DAILY is not enabled (supported_features=0). Raising NotImplementedError. This should not happen - the frontend should check supported_features first."