### PR TITLE
Fix METRIC_SYSTEM import - use correct module

### DIFF
--- a/custom_components/google_weather/config_flow.py
+++ b/custom_components/google_weather/config_flow.py
@@ -8,9 +8,10 @@ import requests
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, METRIC_SYSTEM
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import (
     CONF_ALERTS_DAY_INTERVAL,


### PR DESCRIPTION
Changed import from wrong module to correct one:
- Wrong: from homeassistant.const import METRIC_SYSTEM
- Correct: from homeassistant.util.unit_system import METRIC_SYSTEM

METRIC_SYSTEM constant is in homeassistant.util.unit_system, not in homeassistant.const. This fixes the ImportError.