### PR TITLE
Add translations for multi-page options flow

### DIFF
--- a/custom_components/google_weather/strings.json
+++ b/custom_components/google_weather/strings.json
@@ -84,14 +84,27 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Google Weather Settings",
-        "description": "Update location coordinates, unit system, forecast options, and update intervals. Daily forecasts are always enabled. Changes will take effect after reloading the integration.",
+        "title": "Update Location and Forecast Options",
+        "description": "Update location coordinates, unit system, and choose which forecasts to include. Daily forecasts are always enabled.",
         "data": {
           "latitude": "Latitude",
           "longitude": "Longitude",
           "unit_system": "Unit System",
           "include_hourly_forecast": "Include Hourly Forecasts",
-          "include_alerts": "Include Weather Alerts",
+          "include_alerts": "Include Weather Alerts"
+        },
+        "data_description": {
+          "latitude": "Latitude coordinate for weather data",
+          "longitude": "Longitude coordinate for weather data",
+          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
+          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
+          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls, only shown if supported)"
+        }
+      },
+      "intervals": {
+        "title": "Configure Update Intervals",
+        "description": "Set how often to update each endpoint during day and night. Google provides 10,000 free API calls/month total. All intervals are in minutes.",
+        "data": {
           "current_day_interval": "Current Conditions - Daytime (minutes)",
           "current_night_interval": "Current Conditions - Nighttime (minutes)",
           "daily_day_interval": "Daily Forecast - Daytime (minutes)",
@@ -104,11 +117,6 @@
           "night_end": "Night Time End (HH:MM)"
         },
         "data_description": {
-          "latitude": "Latitude coordinate for weather data",
-          "longitude": "Longitude coordinate for weather data",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
-          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
-          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls, only shown if supported)",
           "current_day_interval": "How often to update current conditions during daytime (1-1440 minutes)",
           "current_night_interval": "How often to update current conditions at night (1-1440 minutes)",
           "daily_day_interval": "How often to update daily forecast during daytime (1-1440 minutes)",

--- a/custom_components/google_weather/translations/en.json
+++ b/custom_components/google_weather/translations/en.json
@@ -28,15 +28,13 @@
         }
       },
       "forecasts": {
-        "title": "Configure Forecast Options",
-        "description": "Choose which optional forecasts and alerts to include. Daily forecasts are always enabled. Disabling hourly forecasts or alerts reduces API usage.",
+        "title": "Configure Hourly Forecasts",
+        "description": "Choose whether to include hourly forecasts. Daily forecasts are always enabled. Weather alerts are enabled by default and can be configured in settings after setup if supported for your location.",
         "data": {
-          "include_hourly_forecast": "Include Hourly Forecasts",
-          "include_alerts": "Include Weather Alerts"
+          "include_hourly_forecast": "Include Hourly Forecasts"
         },
         "data_description": {
-          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
-          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls)"
+          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)"
         }
       },
       "intervals": {
@@ -85,14 +83,27 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Google Weather Settings",
-        "description": "Update location coordinates, unit system, forecast options, and update intervals. Daily forecasts are always enabled. Changes will take effect after reloading the integration.",
+        "title": "Update Location and Forecast Options",
+        "description": "Update location coordinates, unit system, and choose which forecasts to include. Daily forecasts are always enabled.",
         "data": {
           "latitude": "Latitude",
           "longitude": "Longitude",
           "unit_system": "Unit System",
           "include_hourly_forecast": "Include Hourly Forecasts",
-          "include_alerts": "Include Weather Alerts",
+          "include_alerts": "Include Weather Alerts"
+        },
+        "data_description": {
+          "latitude": "Latitude coordinate for weather data",
+          "longitude": "Longitude coordinate for weather data",
+          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
+          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
+          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls, only shown if supported)"
+        }
+      },
+      "intervals": {
+        "title": "Configure Update Intervals",
+        "description": "Set how often to update each endpoint during day and night. Google provides 10,000 free API calls/month total. All intervals are in minutes.",
+        "data": {
           "current_day_interval": "Current Conditions - Daytime (minutes)",
           "current_night_interval": "Current Conditions - Nighttime (minutes)",
           "daily_day_interval": "Daily Forecast - Daytime (minutes)",
@@ -105,11 +116,6 @@
           "night_end": "Night Time End (HH:MM)"
         },
         "data_description": {
-          "latitude": "Latitude coordinate for weather data",
-          "longitude": "Longitude coordinate for weather data",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
-          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
-          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls, only shown if supported)",
           "current_day_interval": "How often to update current conditions during daytime (1-1440 minutes)",
           "current_night_interval": "How often to update current conditions at night (1-1440 minutes)",
           "daily_day_interval": "How often to update daily forecast during daytime (1-1440 minutes)",


### PR DESCRIPTION
Updated strings.json and en.json to support the new multi-page options flow structure:
- init: Location, unit system, and forecast checkboxes
- intervals: Update intervals for enabled endpoints
- confirm: API usage summary

Also updated forecasts step to reflect that alerts checkbox was removed from initial config flow.