### PR TITLE
Fix alerts checkbox in config and options flows

### DIFF
--- a/custom_components/google_weather/strings.json
+++ b/custom_components/google_weather/strings.json
@@ -28,10 +28,11 @@
         }
       },
       "forecasts": {
-        "title": "Configure Hourly Forecasts",
-        "description": "Choose whether to include hourly forecasts. Daily forecasts are always enabled. Weather alerts are enabled by default and can be configured in settings after setup if supported for your location.",
+        "title": "Configure Forecast Options",
+        "description": "Choose which optional forecasts and alerts to include. Daily forecasts are always enabled. Disabling hourly forecasts or alerts reduces API usage.",
         "data": {
           "include_hourly_forecast": "Include Hourly Forecasts",
+          "include_alerts": "Include Weather Alerts"
         },
         "data_description": {
           "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",

--- a/custom_components/google_weather/translations/en.json
+++ b/custom_components/google_weather/translations/en.json
@@ -28,13 +28,15 @@
         }
       },
       "forecasts": {
-        "title": "Configure Hourly Forecasts",
-        "description": "Choose whether to include hourly forecasts. Daily forecasts are always enabled. Weather alerts are enabled by default and can be configured in settings after setup if supported for your location.",
+        "title": "Configure Forecast Options",
+        "description": "Choose which optional forecasts and alerts to include. Daily forecasts are always enabled. Disabling hourly forecasts or alerts reduces API usage.",
         "data": {
-          "include_hourly_forecast": "Include Hourly Forecasts"
+          "include_hourly_forecast": "Include Hourly Forecasts",
+          "include_alerts": "Include Weather Alerts"
         },
         "data_description": {
-          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)"
+          "include_hourly_forecast": "Enable automatic fetching of hourly forecasts (disable to save API calls)",
+          "include_alerts": "Enable automatic fetching of weather alerts (disable to save API calls)"
         }
       },
       "intervals": {


### PR DESCRIPTION
Config flow:
- Restored alerts checkbox to forecasts step (always show since we can't check if alerts are supported during initial setup)

Options flow:
- Fixed alerts checkbox not appearing even when alerts are supported
- Moved alerts_supported check to run before user_input processing
- This ensures the checkbox appears when coordinator reports support

Updated translations in both strings.json and en.json to reflect the restored alerts checkbox in config flow.