### PR TITLE
Fix alerts API calculation when alerts not supported

### DIFF
--- a/custom_components/google_weather/config_flow.py
+++ b/custom_components/google_weather/config_flow.py
@@ -443,10 +443,11 @@ class GoogleWeatherOptionsFlow(config_entries.OptionsFlow):
                     CONF_UNIT_SYSTEM: user_input[CONF_UNIT_SYSTEM],
                 }
                 # Daily forecasts are always enabled (not configurable)
+                # Only include alerts if supported for this location
                 self.forecast_options = {
                     CONF_INCLUDE_DAILY_FORECAST: True,  # Always enabled
                     CONF_INCLUDE_HOURLY_FORECAST: user_input.get(CONF_INCLUDE_HOURLY_FORECAST, DEFAULT_INCLUDE_HOURLY_FORECAST),
-                    CONF_INCLUDE_ALERTS: user_input.get(CONF_INCLUDE_ALERTS, DEFAULT_INCLUDE_ALERTS),
+                    CONF_INCLUDE_ALERTS: user_input.get(CONF_INCLUDE_ALERTS, DEFAULT_INCLUDE_ALERTS) if self.alerts_supported else False,
                 }
                 return await self.async_step_intervals()
 


### PR DESCRIPTION
When alerts are not supported for a location, the confirmation screen was incorrectly showing API calls for alerts. Fixed by ensuring CONF_INCLUDE_ALERTS is set to False in forecast_options when alerts_supported is False, preventing alert API calls from being calculated in the confirmation step.