### PR TITLE
Fix alerts checkbox and entity removal bugs

### DIFF
--- a/custom_components/google_weather/__init__.py
+++ b/custom_components/google_weather/__init__.py
@@ -84,15 +84,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    # Check if alerts were disabled - if so, remove orphaned alert entities
-    old_data = {**entry.data}
-    new_data = {**entry.data, **entry.options}
+    # Get current configuration (data + new options)
+    current_config = {**entry.data, **entry.options}
+    alerts_enabled = current_config.get(CONF_INCLUDE_ALERTS, True)
 
-    old_alerts_enabled = old_data.get(CONF_INCLUDE_ALERTS, True)
-    new_alerts_enabled = new_data.get(CONF_INCLUDE_ALERTS, True)
-
-    # If alerts changed from enabled to disabled, clean up alert entities
-    if old_alerts_enabled and not new_alerts_enabled:
+    # If alerts are now disabled, remove any existing alert entities
+    if not alerts_enabled:
         _LOGGER.info("Alerts disabled - removing orphaned alert binary sensor entities")
         await _remove_alert_entities(hass, entry)
 

--- a/custom_components/google_weather/config_flow.py
+++ b/custom_components/google_weather/config_flow.py
@@ -417,15 +417,15 @@ class GoogleWeatherOptionsFlow(config_entries.OptionsFlow):
             try:
                 coordinator = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
                 if coordinator and hasattr(coordinator, 'alerts_supported'):
-                    # Only show checkbox if alerts are explicitly supported (True)
-                    # Hide if False or None (safer default)
-                    self.alerts_supported = coordinator.alerts_supported is True
+                    # Show checkbox if alerts are supported (True) or not yet determined (None)
+                    # Hide only if explicitly False (not supported)
+                    self.alerts_supported = coordinator.alerts_supported is not False
                 else:
-                    # If coordinator doesn't exist or no attribute, hide checkbox (safer default)
-                    self.alerts_supported = False
+                    # If coordinator doesn't exist or no attribute, show checkbox (allow configuration)
+                    self.alerts_supported = True
             except Exception:
-                # If we can't get coordinator, hide alerts option (safer default)
-                self.alerts_supported = False
+                # If we can't get coordinator, show alerts option
+                self.alerts_supported = True
 
         if user_input is not None:
             # Validate latitude and longitude


### PR DESCRIPTION
1. Fixed alerts checkbox not showing for locations with alerts:
   - Changed logic back to "is not False" to show checkbox when alerts_supported is True OR None (not yet determined)
   - Only hide when explicitly False (not supported)

2. Fixed entity removal logic incorrectly removing entities:
   - Simplified from comparing old vs new (which didn't work because entry.options already has new values when async_update_options runs)
   - Now just checks if alerts are disabled in current config and removes alert entities if so
   - This prevents false positives that were removing entities incorrectly