### PR TITLE
Update documentation to reflect current alert checkbox behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You can choose which optional forecasts and alerts to include during setup:
 
 - **Daily Forecasts**: Always enabled - 10-day forecasts (not configurable, always fetched)
 - **Hourly Forecasts**: Optional - Enable/disable automatic fetching of 240-hour forecasts
-- **Weather Alerts**: Optional - Enable/disable automatic fetching of weather alerts (only shown if supported for your location)
+- **Weather Alerts**: Optional - Enable/disable automatic fetching of weather alerts (checkbox always shown, but alert entities only created if supported in your region)
 
 **Benefits of disabling optional forecasts:**
 - **Reduces API calls**: Disabled endpoints are never fetched automatically, saving API calls

--- a/info.md
+++ b/info.md
@@ -29,7 +29,7 @@ A comprehensive Home Assistant integration for Google Weather API with smart pol
 - Full config and options flow
 - No YAML configuration required
 - Simple API key setup
-- Conditional options (alerts only shown if supported)
+- Auto-detection of regional alert support
 
 ## Quick Start
 


### PR DESCRIPTION
Updated README.md and info.md to accurately describe the current functionality after removing conditional alert checkbox display.

Changes:
- README.md line 210: Clarified that alert checkbox is always shown, but alert entities only created if supported in the region
- info.md line 32: Changed "Conditional options (alerts only shown if supported)" to "Auto-detection of regional alert support"

This ensures documentation matches the implementation where:
- Alert checkbox is always visible in config/options flow
- Alert entities are only created if API supports alerts for location
- Users are informed via UI text that alerts are unavailable in some regions