### PR TITLE
Add translations for top 5 Home Assistant languages

### DIFF
--- a/custom_components/google_weather/translations/de.json
+++ b/custom_components/google_weather/translations/de.json
@@ -1,0 +1,237 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "API-Schlüssel eingeben",
+        "description": "Geben Sie Ihren Google Maps Platform API-Schlüssel ein. Stellen Sie sicher, dass die Wetter-API in Ihrem Google Cloud-Projekt aktiviert ist.",
+        "data": {
+          "api_key": "API-Schlüssel"
+        },
+        "data_description": {
+          "api_key": "Ihr Google Maps Platform API-Schlüssel mit aktivierter Wetter-API"
+        }
+      },
+      "location": {
+        "title": "Standort konfigurieren",
+        "description": "Konfigurieren Sie den Standort und die Einstellungen für Google Weather. Der Standort wird standardmäßig auf Ihre Home Assistant-Konfiguration gesetzt.",
+        "data": {
+          "location": "Standort / Präfix",
+          "latitude": "Breitengrad",
+          "longitude": "Längengrad",
+          "unit_system": "Einheitensystem"
+        },
+        "data_description": {
+          "location": "Standortname für Entitäts-IDs (Standard: 'home'). Beispiele: 'home', 'office', 'gw_home'",
+          "latitude": "Breitengradkoordinate für Wetterdaten (Standard: Home Assistant-Standort)",
+          "longitude": "Längengradkoordinate für Wetterdaten (Standard: Home Assistant-Standort)",
+          "unit_system": "Wählen Sie metrisch (Celsius, km/h, mm) oder imperial (Fahrenheit, mph, Zoll)"
+        }
+      },
+      "forecasts": {
+        "title": "Vorhersageoptionen konfigurieren",
+        "description": "Aktuelle Bedingungen und Tagesvorhersagen sind immer enthalten. Wählen Sie unten zusätzliche Funktionen aus.\n\nDeaktivieren Sie Funktionen, um API-Aufrufe zu sparen. Wetterwarnungen sind in einigen Regionen nicht verfügbar.",
+        "data": {
+          "include_hourly_forecast": "Stündliche Vorhersagen einbeziehen",
+          "include_alerts": "Wetterwarnungen einbeziehen"
+        },
+        "data_description": {
+          "include_hourly_forecast": "Stündliche Wettervorhersagen aktivieren",
+          "include_alerts": "Wetterwarnungen aktivieren (in einigen Regionen nicht verfügbar)"
+        }
+      },
+      "intervals": {
+        "title": "Aktualisierungsintervalle konfigurieren",
+        "description": "Legen Sie fest, wie oft jeder Endpunkt tagsüber und nachts aktualisiert werden soll. Google bietet 10.000 kostenlose API-Aufrufe/Monat insgesamt. Die Standardwerte verwenden ca. 8.640 Aufrufe/Monat (13,6% unter dem Limit). Alle Intervalle sind in Minuten.",
+        "data": {
+          "current_day_interval": "Aktuelle Bedingungen - Tagsüber (Minuten)",
+          "current_night_interval": "Aktuelle Bedingungen - Nachts (Minuten)",
+          "daily_day_interval": "Tagesvorhersage - Tagsüber (Minuten)",
+          "daily_night_interval": "Tagesvorhersage - Nachts (Minuten)",
+          "hourly_day_interval": "Stündliche Vorhersage - Tagsüber (Minuten)",
+          "hourly_night_interval": "Stündliche Vorhersage - Nachts (Minuten)",
+          "alerts_day_interval": "Wetterwarnungen - Tagsüber (Minuten)",
+          "alerts_night_interval": "Wetterwarnungen - Nachts (Minuten)",
+          "night_start": "Beginn der Nachtzeit (HH:MM)",
+          "night_end": "Ende der Nachtzeit (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Wie oft aktuelle Bedingungen tagsüber aktualisiert werden (Standard: 10 Min.)",
+          "current_night_interval": "Wie oft aktuelle Bedingungen nachts aktualisiert werden (Standard: 30 Min.)",
+          "daily_day_interval": "Wie oft Tagesvorhersage tagsüber aktualisiert wird (Standard: 30 Min.)",
+          "daily_night_interval": "Wie oft Tagesvorhersage nachts aktualisiert wird (Standard: 60 Min.)",
+          "hourly_day_interval": "Wie oft stündliche Vorhersage tagsüber aktualisiert wird (Standard: 20 Min.)",
+          "hourly_night_interval": "Wie oft stündliche Vorhersage nachts aktualisiert wird (Standard: 60 Min.)",
+          "alerts_day_interval": "Wie oft Wetterwarnungen tagsüber geprüft werden (Standard: 15 Min.)",
+          "alerts_night_interval": "Wie oft Wetterwarnungen nachts geprüft werden (Standard: 30 Min.)",
+          "night_start": "Wann der nächtliche Aktualisierungsplan beginnt (z.B. 22:00 für 22 Uhr)",
+          "night_end": "Wann der nächtliche Aktualisierungsplan endet (z.B. 06:00 für 6 Uhr)"
+        }
+      },
+      "confirm": {
+        "title": "API-Nutzung bestätigen",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_api_key": "Ungültiger API-Schlüssel oder Wetter-API nicht aktiviert. Bitte überprüfen Sie Ihre Google Cloud Console.",
+      "cannot_connect": "Verbindung zur Google Weather API nicht möglich. Bitte überprüfen Sie Ihre Netzwerkverbindung.",
+      "invalid_latitude": "Breitengrad muss zwischen -90 und 90 liegen",
+      "invalid_longitude": "Längengrad muss zwischen -180 und 180 liegen"
+    },
+    "abort": {
+      "already_configured": "Dieser Standort ist bereits konfiguriert"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Standort und Vorhersageoptionen aktualisieren",
+        "description": "Standort und optionale Funktionen aktualisieren. Aktuelle Bedingungen und Tagesvorhersagen sind immer enthalten.\n\nWetterwarnungen sind in einigen Regionen nicht verfügbar.",
+        "data": {
+          "latitude": "Breitengrad",
+          "longitude": "Längengrad",
+          "unit_system": "Einheitensystem",
+          "include_hourly_forecast": "Stündliche Vorhersagen einbeziehen",
+          "include_alerts": "Wetterwarnungen einbeziehen"
+        },
+        "data_description": {
+          "latitude": "Breitengradkoordinate für Wetterdaten",
+          "longitude": "Längengradkoordinate für Wetterdaten",
+          "unit_system": "Wählen Sie metrisch (Celsius, km/h, mm) oder imperial (Fahrenheit, mph, Zoll)",
+          "include_hourly_forecast": "Stündliche Wettervorhersagen aktivieren",
+          "include_alerts": "Wetterwarnungen aktivieren (in einigen Regionen nicht verfügbar)"
+        }
+      },
+      "intervals": {
+        "title": "Aktualisierungsintervalle konfigurieren",
+        "description": "Legen Sie fest, wie oft jeder Endpunkt tagsüber und nachts aktualisiert werden soll. Google bietet 10.000 kostenlose API-Aufrufe/Monat insgesamt. Alle Intervalle sind in Minuten.",
+        "data": {
+          "current_day_interval": "Aktuelle Bedingungen - Tagsüber (Minuten)",
+          "current_night_interval": "Aktuelle Bedingungen - Nachts (Minuten)",
+          "daily_day_interval": "Tagesvorhersage - Tagsüber (Minuten)",
+          "daily_night_interval": "Tagesvorhersage - Nachts (Minuten)",
+          "hourly_day_interval": "Stündliche Vorhersage - Tagsüber (Minuten)",
+          "hourly_night_interval": "Stündliche Vorhersage - Nachts (Minuten)",
+          "alerts_day_interval": "Wetterwarnungen - Tagsüber (Minuten)",
+          "alerts_night_interval": "Wetterwarnungen - Nachts (Minuten)",
+          "night_start": "Beginn der Nachtzeit (HH:MM)",
+          "night_end": "Ende der Nachtzeit (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Wie oft aktuelle Bedingungen tagsüber aktualisiert werden (1-1440 Minuten)",
+          "current_night_interval": "Wie oft aktuelle Bedingungen nachts aktualisiert werden (1-1440 Minuten)",
+          "daily_day_interval": "Wie oft Tagesvorhersage tagsüber aktualisiert wird (1-1440 Minuten)",
+          "daily_night_interval": "Wie oft Tagesvorhersage nachts aktualisiert wird (1-1440 Minuten)",
+          "hourly_day_interval": "Wie oft stündliche Vorhersage tagsüber aktualisiert wird (1-1440 Minuten)",
+          "hourly_night_interval": "Wie oft stündliche Vorhersage nachts aktualisiert wird (1-1440 Minuten)",
+          "alerts_day_interval": "Wie oft Wetterwarnungen tagsüber geprüft werden (1-1440 Minuten)",
+          "alerts_night_interval": "Wie oft Wetterwarnungen nachts geprüft werden (1-1440 Minuten)",
+          "night_start": "Wann der nächtliche Aktualisierungsplan beginnt (z.B. 22:00)",
+          "night_end": "Wann der nächtliche Aktualisierungsplan endet (z.B. 06:00)"
+        }
+      },
+      "confirm": {
+        "title": "API-Nutzung bestätigen",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_latitude": "Breitengrad muss zwischen -90 und 90 liegen",
+      "invalid_longitude": "Längengrad muss zwischen -180 und 180 liegen"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "feels_like": {
+        "name": "Gefühlte Temperatur"
+      },
+      "dew_point": {
+        "name": "Taupunkt"
+      },
+      "heat_index": {
+        "name": "Hitzeindex"
+      },
+      "wind_chill": {
+        "name": "Windchill"
+      },
+      "humidity": {
+        "name": "Luftfeuchtigkeit"
+      },
+      "pressure": {
+        "name": "Luftdruck"
+      },
+      "wind_speed": {
+        "name": "Windgeschwindigkeit"
+      },
+      "wind_gust": {
+        "name": "Windböen"
+      },
+      "wind_direction": {
+        "name": "Windrichtung"
+      },
+      "visibility": {
+        "name": "Sichtweite"
+      },
+      "cloud_cover": {
+        "name": "Bewölkung"
+      },
+      "uv_index": {
+        "name": "UV-Index"
+      },
+      "precipitation_probability": {
+        "name": "Niederschlagswahrscheinlichkeit"
+      },
+      "precipitation_amount": {
+        "name": "Niederschlagsmenge"
+      },
+      "thunderstorm_probability": {
+        "name": "Gewitterwahrscheinlichkeit"
+      },
+      "temp_change_24h": {
+        "name": "Temperaturänderung (24h)"
+      },
+      "max_temp_24h": {
+        "name": "Höchsttemperatur (24h)"
+      },
+      "min_temp_24h": {
+        "name": "Tiefsttemperatur (24h)"
+      },
+      "precipitation_24h": {
+        "name": "Niederschlag (24h)"
+      },
+      "weather_condition": {
+        "name": "Wetterzustand"
+      }
+    },
+    "binary_sensor": {
+      "weather_alert": {
+        "name": "Wetterwarnung"
+      },
+      "severe_weather_alert": {
+        "name": "Unwetterwarnung"
+      },
+      "urgent_weather_alert": {
+        "name": "Dringende Wetterwarnung"
+      }
+    }
+  },
+  "services": {
+    "get_forecast": {
+      "name": "Vorhersage auf Anfrage abrufen",
+      "description": "Wettervorhersage auf Anfrage abrufen, auch wenn automatische Abfrage deaktiviert ist. Dieser Dienst führt einen einzelnen API-Aufruf durch, um den angeforderten Vorhersagetyp abzurufen.",
+      "fields": {
+        "entity_id": {
+          "name": "Entitäts-ID",
+          "description": "Die Wetter-Entitäts-ID, für die Vorhersagen abgerufen werden sollen."
+        },
+        "forecast_type": {
+          "name": "Vorhersagetyp",
+          "description": "Typ der abzurufenden Vorhersage (täglich oder stündlich)."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/google_weather/translations/es.json
+++ b/custom_components/google_weather/translations/es.json
@@ -1,0 +1,237 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ingresar clave API",
+        "description": "Ingrese su clave API de Google Maps Platform. Asegúrese de que la API del clima esté habilitada en su proyecto de Google Cloud.",
+        "data": {
+          "api_key": "Clave API"
+        },
+        "data_description": {
+          "api_key": "Su clave API de Google Maps Platform con la API del clima habilitada"
+        }
+      },
+      "location": {
+        "title": "Configurar ubicación",
+        "description": "Configure la ubicación y ajustes de Google Weather. La ubicación se establecerá de forma predeterminada en su configuración de Home Assistant.",
+        "data": {
+          "location": "Ubicación / Prefijo",
+          "latitude": "Latitud",
+          "longitude": "Longitud",
+          "unit_system": "Sistema de unidades"
+        },
+        "data_description": {
+          "location": "Nombre de ubicación usado para IDs de entidad (predeterminado: 'home'). Ejemplos: 'home', 'office', 'gw_home'",
+          "latitude": "Coordenada de latitud para datos meteorológicos (predeterminado: ubicación de Home Assistant)",
+          "longitude": "Coordenada de longitud para datos meteorológicos (predeterminado: ubicación de Home Assistant)",
+          "unit_system": "Elija métrico (Celsius, km/h, mm) o imperial (Fahrenheit, mph, pulgadas)"
+        }
+      },
+      "forecasts": {
+        "title": "Configurar opciones de pronóstico",
+        "description": "Las condiciones actuales y los pronósticos diarios siempre están incluidos. Seleccione características adicionales a continuación.\n\nDesactive características para ahorrar llamadas a la API. Las alertas meteorológicas no están disponibles en algunas regiones.",
+        "data": {
+          "include_hourly_forecast": "Incluir pronósticos por hora",
+          "include_alerts": "Incluir alertas meteorológicas"
+        },
+        "data_description": {
+          "include_hourly_forecast": "Habilitar pronósticos meteorológicos por hora",
+          "include_alerts": "Habilitar alertas meteorológicas (no disponibles en algunas regiones)"
+        }
+      },
+      "intervals": {
+        "title": "Configurar intervalos de actualización",
+        "description": "Establezca con qué frecuencia actualizar cada punto final durante el día y la noche. Google proporciona 10,000 llamadas API gratuitas/mes en total. Los valores predeterminados utilizan aproximadamente 8,640 llamadas/mes (13,6% por debajo del límite). Todos los intervalos están en minutos.",
+        "data": {
+          "current_day_interval": "Condiciones actuales - Día (minutos)",
+          "current_night_interval": "Condiciones actuales - Noche (minutos)",
+          "daily_day_interval": "Pronóstico diario - Día (minutos)",
+          "daily_night_interval": "Pronóstico diario - Noche (minutos)",
+          "hourly_day_interval": "Pronóstico por hora - Día (minutos)",
+          "hourly_night_interval": "Pronóstico por hora - Noche (minutos)",
+          "alerts_day_interval": "Alertas meteorológicas - Día (minutos)",
+          "alerts_night_interval": "Alertas meteorológicas - Noche (minutos)",
+          "night_start": "Inicio de la noche (HH:MM)",
+          "night_end": "Fin de la noche (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Con qué frecuencia actualizar las condiciones actuales durante el día (predeterminado: 10 min)",
+          "current_night_interval": "Con qué frecuencia actualizar las condiciones actuales por la noche (predeterminado: 30 min)",
+          "daily_day_interval": "Con qué frecuencia actualizar el pronóstico diario durante el día (predeterminado: 30 min)",
+          "daily_night_interval": "Con qué frecuencia actualizar el pronóstico diario por la noche (predeterminado: 60 min)",
+          "hourly_day_interval": "Con qué frecuencia actualizar el pronóstico por hora durante el día (predeterminado: 20 min)",
+          "hourly_night_interval": "Con qué frecuencia actualizar el pronóstico por hora por la noche (predeterminado: 60 min)",
+          "alerts_day_interval": "Con qué frecuencia verificar alertas meteorológicas durante el día (predeterminado: 15 min)",
+          "alerts_night_interval": "Con qué frecuencia verificar alertas meteorológicas por la noche (predeterminado: 30 min)",
+          "night_start": "Cuándo comienza el programa de actualización nocturna (ej: 22:00 para las 10 PM)",
+          "night_end": "Cuándo finaliza el programa de actualización nocturna (ej: 06:00 para las 6 AM)"
+        }
+      },
+      "confirm": {
+        "title": "Confirmar uso de API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_api_key": "Clave API inválida o API del clima no habilitada. Verifique su consola de Google Cloud.",
+      "cannot_connect": "No se puede conectar a la API de Google Weather. Verifique su conexión de red.",
+      "invalid_latitude": "La latitud debe estar entre -90 y 90",
+      "invalid_longitude": "La longitud debe estar entre -180 y 180"
+    },
+    "abort": {
+      "already_configured": "Esta ubicación ya está configurada"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Actualizar ubicación y opciones de pronóstico",
+        "description": "Actualice la ubicación y las características opcionales. Las condiciones actuales y los pronósticos diarios siempre están incluidos.\n\nLas alertas meteorológicas no están disponibles en algunas regiones.",
+        "data": {
+          "latitude": "Latitud",
+          "longitude": "Longitud",
+          "unit_system": "Sistema de unidades",
+          "include_hourly_forecast": "Incluir pronósticos por hora",
+          "include_alerts": "Incluir alertas meteorológicas"
+        },
+        "data_description": {
+          "latitude": "Coordenada de latitud para datos meteorológicos",
+          "longitude": "Coordenada de longitud para datos meteorológicos",
+          "unit_system": "Elija métrico (Celsius, km/h, mm) o imperial (Fahrenheit, mph, pulgadas)",
+          "include_hourly_forecast": "Habilitar pronósticos meteorológicos por hora",
+          "include_alerts": "Habilitar alertas meteorológicas (no disponibles en algunas regiones)"
+        }
+      },
+      "intervals": {
+        "title": "Configurar intervalos de actualización",
+        "description": "Establezca con qué frecuencia actualizar cada punto final durante el día y la noche. Google proporciona 10,000 llamadas API gratuitas/mes en total. Todos los intervallos están en minutos.",
+        "data": {
+          "current_day_interval": "Condiciones actuales - Día (minutos)",
+          "current_night_interval": "Condiciones actuales - Noche (minutos)",
+          "daily_day_interval": "Pronóstico diario - Día (minutos)",
+          "daily_night_interval": "Pronóstico diario - Noche (minutos)",
+          "hourly_day_interval": "Pronóstico por hora - Día (minutos)",
+          "hourly_night_interval": "Pronóstico por hora - Noche (minutos)",
+          "alerts_day_interval": "Alertas meteorológicas - Día (minutos)",
+          "alerts_night_interval": "Alertas meteorológicas - Noche (minutos)",
+          "night_start": "Inicio de la noche (HH:MM)",
+          "night_end": "Fin de la noche (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Con qué frecuencia actualizar las condiciones actuales durante el día (1-1440 minutos)",
+          "current_night_interval": "Con qué frecuencia actualizar las condiciones actuales por la noche (1-1440 minutos)",
+          "daily_day_interval": "Con qué frecuencia actualizar el pronóstico diario durante el día (1-1440 minutos)",
+          "daily_night_interval": "Con qué frecuencia actualizar el pronóstico diario por la noche (1-1440 minutos)",
+          "hourly_day_interval": "Con qué frecuencia actualizar el pronóstico por hora durante el día (1-1440 minutos)",
+          "hourly_night_interval": "Con qué frecuencia actualizar el pronóstico por hora por la noche (1-1440 minutos)",
+          "alerts_day_interval": "Con qué frecuencia verificar alertas meteorológicas durante el día (1-1440 minutos)",
+          "alerts_night_interval": "Con qué frecuencia verificar alertas meteorológicas por la noche (1-1440 minutos)",
+          "night_start": "Cuándo comienza el programa de actualización nocturna (ej: 22:00)",
+          "night_end": "Cuándo finaliza el programa de actualización nocturna (ej: 06:00)"
+        }
+      },
+      "confirm": {
+        "title": "Confirmar uso de API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_latitude": "La latitud debe estar entre -90 y 90",
+      "invalid_longitude": "La longitud debe estar entre -180 y 180"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "feels_like": {
+        "name": "Sensación térmica"
+      },
+      "dew_point": {
+        "name": "Punto de rocío"
+      },
+      "heat_index": {
+        "name": "Índice de calor"
+      },
+      "wind_chill": {
+        "name": "Sensación térmica por viento"
+      },
+      "humidity": {
+        "name": "Humedad"
+      },
+      "pressure": {
+        "name": "Presión"
+      },
+      "wind_speed": {
+        "name": "Velocidad del viento"
+      },
+      "wind_gust": {
+        "name": "Ráfagas de viento"
+      },
+      "wind_direction": {
+        "name": "Dirección del viento"
+      },
+      "visibility": {
+        "name": "Visibilidad"
+      },
+      "cloud_cover": {
+        "name": "Nubosidad"
+      },
+      "uv_index": {
+        "name": "Índice UV"
+      },
+      "precipitation_probability": {
+        "name": "Probabilidad de precipitación"
+      },
+      "precipitation_amount": {
+        "name": "Cantidad de precipitación"
+      },
+      "thunderstorm_probability": {
+        "name": "Probabilidad de tormenta"
+      },
+      "temp_change_24h": {
+        "name": "Cambio de temperatura (24h)"
+      },
+      "max_temp_24h": {
+        "name": "Temperatura máxima (24h)"
+      },
+      "min_temp_24h": {
+        "name": "Temperatura mínima (24h)"
+      },
+      "precipitation_24h": {
+        "name": "Precipitación (24h)"
+      },
+      "weather_condition": {
+        "name": "Condiciones meteorológicas"
+      }
+    },
+    "binary_sensor": {
+      "weather_alert": {
+        "name": "Alerta meteorológica"
+      },
+      "severe_weather_alert": {
+        "name": "Alerta meteorológica severa"
+      },
+      "urgent_weather_alert": {
+        "name": "Alerta meteorológica urgente"
+      }
+    }
+  },
+  "services": {
+    "get_forecast": {
+      "name": "Obtener pronóstico bajo demanda",
+      "description": "Obtenga el pronóstico meteorológico bajo demanda, incluso cuando el sondeo automático esté deshabilitado. Este servicio realiza una única llamada a la API para obtener el tipo de pronóstico solicitado.",
+      "fields": {
+        "entity_id": {
+          "name": "ID de entidad",
+          "description": "El ID de la entidad meteorológica para la que obtener pronósticos."
+        },
+        "forecast_type": {
+          "name": "Tipo de pronóstico",
+          "description": "Tipo de pronóstico a obtener (diario u horario)."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/google_weather/translations/fr.json
+++ b/custom_components/google_weather/translations/fr.json
@@ -1,0 +1,237 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Saisir la clé API",
+        "description": "Saisissez votre clé API Google Maps Platform. Assurez-vous que l'API Météo est activée dans votre projet Google Cloud.",
+        "data": {
+          "api_key": "Clé API"
+        },
+        "data_description": {
+          "api_key": "Votre clé API Google Maps Platform avec l'API Météo activée"
+        }
+      },
+      "location": {
+        "title": "Configurer l'emplacement",
+        "description": "Configurez l'emplacement et les paramètres de Google Weather. L'emplacement sera défini par défaut sur votre configuration Home Assistant.",
+        "data": {
+          "location": "Emplacement / Préfixe",
+          "latitude": "Latitude",
+          "longitude": "Longitude",
+          "unit_system": "Système d'unités"
+        },
+        "data_description": {
+          "location": "Nom de l'emplacement utilisé pour les ID d'entité (par défaut : 'home'). Exemples : 'home', 'office', 'gw_home'",
+          "latitude": "Coordonnée de latitude pour les données météo (par défaut : emplacement Home Assistant)",
+          "longitude": "Coordonnée de longitude pour les données météo (par défaut : emplacement Home Assistant)",
+          "unit_system": "Choisissez métrique (Celsius, km/h, mm) ou impérial (Fahrenheit, mph, pouces)"
+        }
+      },
+      "forecasts": {
+        "title": "Configurer les options de prévision",
+        "description": "Les conditions actuelles et les prévisions quotidiennes sont toujours incluses. Sélectionnez les fonctionnalités supplémentaires ci-dessous.\n\nDésactivez les fonctionnalités pour économiser les appels API. Les alertes météo ne sont pas disponibles dans certaines régions.",
+        "data": {
+          "include_hourly_forecast": "Inclure les prévisions horaires",
+          "include_alerts": "Inclure les alertes météo"
+        },
+        "data_description": {
+          "include_hourly_forecast": "Activer les prévisions météo horaires",
+          "include_alerts": "Activer les alertes météo (non disponibles dans certaines régions)"
+        }
+      },
+      "intervals": {
+        "title": "Configurer les intervalles de mise à jour",
+        "description": "Définissez la fréquence de mise à jour de chaque point de terminaison pendant la journée et la nuit. Google fournit 10 000 appels API gratuits/mois au total. Les valeurs par défaut utilisent environ 8 640 appels/mois (13,6% sous la limite). Tous les intervalles sont en minutes.",
+        "data": {
+          "current_day_interval": "Conditions actuelles - Journée (minutes)",
+          "current_night_interval": "Conditions actuelles - Nuit (minutes)",
+          "daily_day_interval": "Prévision quotidienne - Journée (minutes)",
+          "daily_night_interval": "Prévision quotidienne - Nuit (minutes)",
+          "hourly_day_interval": "Prévision horaire - Journée (minutes)",
+          "hourly_night_interval": "Prévision horaire - Nuit (minutes)",
+          "alerts_day_interval": "Alertes météo - Journée (minutes)",
+          "alerts_night_interval": "Alertes météo - Nuit (minutes)",
+          "night_start": "Début de la nuit (HH:MM)",
+          "night_end": "Fin de la nuit (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Fréquence de mise à jour des conditions actuelles pendant la journée (par défaut : 10 min)",
+          "current_night_interval": "Fréquence de mise à jour des conditions actuelles la nuit (par défaut : 30 min)",
+          "daily_day_interval": "Fréquence de mise à jour de la prévision quotidienne pendant la journée (par défaut : 30 min)",
+          "daily_night_interval": "Fréquence de mise à jour de la prévision quotidienne la nuit (par défaut : 60 min)",
+          "hourly_day_interval": "Fréquence de mise à jour de la prévision horaire pendant la journée (par défaut : 20 min)",
+          "hourly_night_interval": "Fréquence de mise à jour de la prévision horaire la nuit (par défaut : 60 min)",
+          "alerts_day_interval": "Fréquence de vérification des alertes météo pendant la journée (par défaut : 15 min)",
+          "alerts_night_interval": "Fréquence de vérification des alertes météo la nuit (par défaut : 30 min)",
+          "night_start": "Quand le programme de mise à jour nocturne commence (ex : 22:00 pour 22h)",
+          "night_end": "Quand le programme de mise à jour nocturne se termine (ex : 06:00 pour 6h)"
+        }
+      },
+      "confirm": {
+        "title": "Confirmer l'utilisation de l'API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_api_key": "Clé API invalide ou API Météo non activée. Veuillez vérifier votre console Google Cloud.",
+      "cannot_connect": "Impossible de se connecter à l'API Google Weather. Veuillez vérifier votre connexion réseau.",
+      "invalid_latitude": "La latitude doit être comprise entre -90 et 90",
+      "invalid_longitude": "La longitude doit être comprise entre -180 et 180"
+    },
+    "abort": {
+      "already_configured": "Cet emplacement est déjà configuré"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Mettre à jour l'emplacement et les options de prévision",
+        "description": "Mettez à jour l'emplacement et les fonctionnalités optionnelles. Les conditions actuelles et les prévisions quotidiennes sont toujours incluses.\n\nLes alertes météo ne sont pas disponibles dans certaines régions.",
+        "data": {
+          "latitude": "Latitude",
+          "longitude": "Longitude",
+          "unit_system": "Système d'unités",
+          "include_hourly_forecast": "Inclure les prévisions horaires",
+          "include_alerts": "Inclure les alertes météo"
+        },
+        "data_description": {
+          "latitude": "Coordonnée de latitude pour les données météo",
+          "longitude": "Coordonnée de longitude pour les données météo",
+          "unit_system": "Choisissez métrique (Celsius, km/h, mm) ou impérial (Fahrenheit, mph, pouces)",
+          "include_hourly_forecast": "Activer les prévisions météo horaires",
+          "include_alerts": "Activer les alertes météo (non disponibles dans certaines régions)"
+        }
+      },
+      "intervals": {
+        "title": "Configurer les intervalles de mise à jour",
+        "description": "Définissez la fréquence de mise à jour de chaque point de terminaison pendant la journée et la nuit. Google fournit 10 000 appels API gratuits/mois au total. Tous les intervalles sont en minutes.",
+        "data": {
+          "current_day_interval": "Conditions actuelles - Journée (minutes)",
+          "current_night_interval": "Conditions actuelles - Nuit (minutes)",
+          "daily_day_interval": "Prévision quotidienne - Journée (minutes)",
+          "daily_night_interval": "Prévision quotidienne - Nuit (minutes)",
+          "hourly_day_interval": "Prévision horaire - Journée (minutes)",
+          "hourly_night_interval": "Prévision horaire - Nuit (minutes)",
+          "alerts_day_interval": "Alertes météo - Journée (minutes)",
+          "alerts_night_interval": "Alertes météo - Nuit (minutes)",
+          "night_start": "Début de la nuit (HH:MM)",
+          "night_end": "Fin de la nuit (HH:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Fréquence de mise à jour des conditions actuelles pendant la journée (1-1440 minutes)",
+          "current_night_interval": "Fréquence de mise à jour des conditions actuelles la nuit (1-1440 minutes)",
+          "daily_day_interval": "Fréquence de mise à jour de la prévision quotidienne pendant la journée (1-1440 minutes)",
+          "daily_night_interval": "Fréquence de mise à jour de la prévision quotidienne la nuit (1-1440 minutes)",
+          "hourly_day_interval": "Fréquence de mise à jour de la prévision horaire pendant la journée (1-1440 minutes)",
+          "hourly_night_interval": "Fréquence de mise à jour de la prévision horaire la nuit (1-1440 minutes)",
+          "alerts_day_interval": "Fréquence de vérification des alertes météo pendant la journée (1-1440 minutes)",
+          "alerts_night_interval": "Fréquence de vérification des alertes météo la nuit (1-1440 minutes)",
+          "night_start": "Quand le programme de mise à jour nocturne commence (ex : 22:00)",
+          "night_end": "Quand le programme de mise à jour nocturne se termine (ex : 06:00)"
+        }
+      },
+      "confirm": {
+        "title": "Confirmer l'utilisation de l'API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_latitude": "La latitude doit être comprise entre -90 et 90",
+      "invalid_longitude": "La longitude doit être comprise entre -180 et 180"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Température"
+      },
+      "feels_like": {
+        "name": "Température ressentie"
+      },
+      "dew_point": {
+        "name": "Point de rosée"
+      },
+      "heat_index": {
+        "name": "Indice de chaleur"
+      },
+      "wind_chill": {
+        "name": "Refroidissement éolien"
+      },
+      "humidity": {
+        "name": "Humidité"
+      },
+      "pressure": {
+        "name": "Pression"
+      },
+      "wind_speed": {
+        "name": "Vitesse du vent"
+      },
+      "wind_gust": {
+        "name": "Rafales de vent"
+      },
+      "wind_direction": {
+        "name": "Direction du vent"
+      },
+      "visibility": {
+        "name": "Visibilité"
+      },
+      "cloud_cover": {
+        "name": "Couverture nuageuse"
+      },
+      "uv_index": {
+        "name": "Indice UV"
+      },
+      "precipitation_probability": {
+        "name": "Probabilité de précipitations"
+      },
+      "precipitation_amount": {
+        "name": "Quantité de précipitations"
+      },
+      "thunderstorm_probability": {
+        "name": "Probabilité d'orage"
+      },
+      "temp_change_24h": {
+        "name": "Changement de température (24h)"
+      },
+      "max_temp_24h": {
+        "name": "Température maximale (24h)"
+      },
+      "min_temp_24h": {
+        "name": "Température minimale (24h)"
+      },
+      "precipitation_24h": {
+        "name": "Précipitations (24h)"
+      },
+      "weather_condition": {
+        "name": "Conditions météo"
+      }
+    },
+    "binary_sensor": {
+      "weather_alert": {
+        "name": "Alerte météo"
+      },
+      "severe_weather_alert": {
+        "name": "Alerte météo sévère"
+      },
+      "urgent_weather_alert": {
+        "name": "Alerte météo urgente"
+      }
+    }
+  },
+  "services": {
+    "get_forecast": {
+      "name": "Obtenir les prévisions à la demande",
+      "description": "Récupérez les prévisions météo à la demande, même lorsque l'interrogation automatique est désactivée. Ce service effectue un seul appel API pour récupérer le type de prévision demandé.",
+      "fields": {
+        "entity_id": {
+          "name": "ID d'entité",
+          "description": "L'ID de l'entité météo pour laquelle récupérer les prévisions."
+        },
+        "forecast_type": {
+          "name": "Type de prévision",
+          "description": "Type de prévision à récupérer (quotidienne ou horaire)."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/google_weather/translations/nl.json
+++ b/custom_components/google_weather/translations/nl.json
@@ -1,0 +1,237 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "API-sleutel invoeren",
+        "description": "Voer uw Google Maps Platform API-sleutel in. Zorg ervoor dat de Weather API is ingeschakeld in uw Google Cloud-project.",
+        "data": {
+          "api_key": "API-sleutel"
+        },
+        "data_description": {
+          "api_key": "Uw Google Maps Platform API-sleutel met Weather API ingeschakeld"
+        }
+      },
+      "location": {
+        "title": "Locatie configureren",
+        "description": "Configureer de locatie en instellingen voor Google Weather. De locatie wordt standaard ingesteld op uw Home Assistant-configuratie.",
+        "data": {
+          "location": "Locatie / Voorvoegsel",
+          "latitude": "Breedtegraad",
+          "longitude": "Lengtegraad",
+          "unit_system": "Eenheidssysteem"
+        },
+        "data_description": {
+          "location": "Locatienaam gebruikt voor entiteit-ID's (standaard: 'home'). Voorbeelden: 'home', 'office', 'gw_home'",
+          "latitude": "Breedtegraadcoördinaat voor weergegevens (standaard: Home Assistant-locatie)",
+          "longitude": "Lengtegraadcoördinaat voor weergegevens (standaard: Home Assistant-locatie)",
+          "unit_system": "Kies metrisch (Celsius, km/u, mm) of imperiaal (Fahrenheit, mph, inches)"
+        }
+      },
+      "forecasts": {
+        "title": "Voorspellingsopties configureren",
+        "description": "Huidige omstandigheden en dagelijkse voorspellingen zijn altijd inbegrepen. Selecteer hieronder aanvullende functies.\n\nSchakel functies uit om API-aanroepen te besparen. Weerwaarschuwingen zijn in sommige regio's niet beschikbaar.",
+        "data": {
+          "include_hourly_forecast": "Uurlijkse voorspellingen opnemen",
+          "include_alerts": "Weerwaarschuwingen opnemen"
+        },
+        "data_description": {
+          "include_hourly_forecast": "Schakel uurlijkse weervoorspellingen in",
+          "include_alerts": "Schakel weerwaarschuwingen in (niet beschikbaar in sommige regio's)"
+        }
+      },
+      "intervals": {
+        "title": "Update-intervallen configureren",
+        "description": "Stel in hoe vaak elk eindpunt overdag en 's nachts wordt bijgewerkt. Google biedt in totaal 10.000 gratis API-aanroepen/maand. De standaardwaarden gebruiken ongeveer 8.640 aanroepen/maand (13,6% onder de limiet). Alle intervallen zijn in minuten.",
+        "data": {
+          "current_day_interval": "Huidige omstandigheden - Overdag (minuten)",
+          "current_night_interval": "Huidige omstandigheden - 's Nachts (minuten)",
+          "daily_day_interval": "Dagelijkse voorspelling - Overdag (minuten)",
+          "daily_night_interval": "Dagelijkse voorspelling - 's Nachts (minuten)",
+          "hourly_day_interval": "Uurlijkse voorspelling - Overdag (minuten)",
+          "hourly_night_interval": "Uurlijkse voorspelling - 's Nachts (minuten)",
+          "alerts_day_interval": "Weerwaarschuwingen - Overdag (minuten)",
+          "alerts_night_interval": "Weerwaarschuwingen - 's Nachts (minuten)",
+          "night_start": "Begin nachttijd (UU:MM)",
+          "night_end": "Einde nachttijd (UU:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Hoe vaak huidige omstandigheden overdag worden bijgewerkt (standaard: 10 min)",
+          "current_night_interval": "Hoe vaak huidige omstandigheden 's nachts worden bijgewerkt (standaard: 30 min)",
+          "daily_day_interval": "Hoe vaak dagelijkse voorspelling overdag wordt bijgewerkt (standaard: 30 min)",
+          "daily_night_interval": "Hoe vaak dagelijkse voorspelling 's nachts wordt bijgewerkt (standaard: 60 min)",
+          "hourly_day_interval": "Hoe vaak uurlijkse voorspelling overdag wordt bijgewerkt (standaard: 20 min)",
+          "hourly_night_interval": "Hoe vaak uurlijkse voorspelling 's nachts wordt bijgewerkt (standaard: 60 min)",
+          "alerts_day_interval": "Hoe vaak weerwaarschuwingen overdag worden gecontroleerd (standaard: 15 min)",
+          "alerts_night_interval": "Hoe vaak weerwaarschuwingen 's nachts worden gecontroleerd (standaard: 30 min)",
+          "night_start": "Wanneer het nachtelijke update-schema begint (bijv. 22:00 voor 22 uur)",
+          "night_end": "Wanneer het nachtelijke update-schema eindigt (bijv. 06:00 voor 6 uur)"
+        }
+      },
+      "confirm": {
+        "title": "API-gebruik bevestigen",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_api_key": "Ongeldige API-sleutel of Weather API niet ingeschakeld. Controleer uw Google Cloud Console.",
+      "cannot_connect": "Kan geen verbinding maken met Google Weather API. Controleer uw netwerkverbinding.",
+      "invalid_latitude": "Breedtegraad moet tussen -90 en 90 liggen",
+      "invalid_longitude": "Lengtegraad moet tussen -180 en 180 liggen"
+    },
+    "abort": {
+      "already_configured": "Deze locatie is al geconfigureerd"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Locatie en voorspellingsopties bijwerken",
+        "description": "Werk locatie en optionele functies bij. Huidige omstandigheden en dagelijkse voorspellingen zijn altijd inbegrepen.\n\nWeerwaarschuwingen zijn in sommige regio's niet beschikbaar.",
+        "data": {
+          "latitude": "Breedtegraad",
+          "longitude": "Lengtegraad",
+          "unit_system": "Eenheidssysteem",
+          "include_hourly_forecast": "Uurlijkse voorspellingen opnemen",
+          "include_alerts": "Weerwaarschuwingen opnemen"
+        },
+        "data_description": {
+          "latitude": "Breedtegraadcoördinaat voor weergegevens",
+          "longitude": "Lengtegraadcoördinaat voor weergegevens",
+          "unit_system": "Kies metrisch (Celsius, km/u, mm) of imperiaal (Fahrenheit, mph, inches)",
+          "include_hourly_forecast": "Schakel uurlijkse weervoorspellingen in",
+          "include_alerts": "Schakel weerwaarschuwingen in (niet beschikbaar in sommige regio's)"
+        }
+      },
+      "intervals": {
+        "title": "Update-intervallen configureren",
+        "description": "Stel in hoe vaak elk eindpunt overdag en 's nachts wordt bijgewerkt. Google biedt in totaal 10.000 gratis API-aanroepen/maand. Alle intervallen zijn in minuten.",
+        "data": {
+          "current_day_interval": "Huidige omstandigheden - Overdag (minuten)",
+          "current_night_interval": "Huidige omstandigheden - 's Nachts (minuten)",
+          "daily_day_interval": "Dagelijkse voorspelling - Overdag (minuten)",
+          "daily_night_interval": "Dagelijkse voorspelling - 's Nachts (minuten)",
+          "hourly_day_interval": "Uurlijkse voorspelling - Overdag (minuten)",
+          "hourly_night_interval": "Uurlijkse voorspelling - 's Nachts (minuten)",
+          "alerts_day_interval": "Weerwaarschuwingen - Overdag (minuten)",
+          "alerts_night_interval": "Weerwaarschuwingen - 's Nachts (minuten)",
+          "night_start": "Begin nachttijd (UU:MM)",
+          "night_end": "Einde nachttijd (UU:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Hoe vaak huidige omstandigheden overdag worden bijgewerkt (1-1440 minuten)",
+          "current_night_interval": "Hoe vaak huidige omstandigheden 's nachts worden bijgewerkt (1-1440 minuten)",
+          "daily_day_interval": "Hoe vaak dagelijkse voorspelling overdag wordt bijgewerkt (1-1440 minuten)",
+          "daily_night_interval": "Hoe vaak dagelijkse voorspelling 's nachts wordt bijgewerkt (1-1440 minuten)",
+          "hourly_day_interval": "Hoe vaak uurlijkse voorspelling overdag wordt bijgewerkt (1-1440 minuten)",
+          "hourly_night_interval": "Hoe vaak uurlijkse voorspelling 's nachts wordt bijgewerkt (1-1440 minuten)",
+          "alerts_day_interval": "Hoe vaak weerwaarschuwingen overdag worden gecontroleerd (1-1440 minuten)",
+          "alerts_night_interval": "Hoe vaak weerwaarschuwingen 's nachts worden gecontroleerd (1-1440 minuten)",
+          "night_start": "Wanneer het nachtelijke update-schema begint (bijv. 22:00)",
+          "night_end": "Wanneer het nachtelijke update-schema eindigt (bijv. 06:00)"
+        }
+      },
+      "confirm": {
+        "title": "API-gebruik bevestigen",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_latitude": "Breedtegraad moet tussen -90 en 90 liggen",
+      "invalid_longitude": "Lengtegraad moet tussen -180 en 180 liggen"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperatuur"
+      },
+      "feels_like": {
+        "name": "Gevoelstemperatuur"
+      },
+      "dew_point": {
+        "name": "Dauwpunt"
+      },
+      "heat_index": {
+        "name": "Hitte-index"
+      },
+      "wind_chill": {
+        "name": "Gevoelstemperatuur wind"
+      },
+      "humidity": {
+        "name": "Luchtvochtigheid"
+      },
+      "pressure": {
+        "name": "Luchtdruk"
+      },
+      "wind_speed": {
+        "name": "Windsnelheid"
+      },
+      "wind_gust": {
+        "name": "Windstoten"
+      },
+      "wind_direction": {
+        "name": "Windrichting"
+      },
+      "visibility": {
+        "name": "Zicht"
+      },
+      "cloud_cover": {
+        "name": "Bewolking"
+      },
+      "uv_index": {
+        "name": "UV-index"
+      },
+      "precipitation_probability": {
+        "name": "Neerslagkans"
+      },
+      "precipitation_amount": {
+        "name": "Neerslaghoeveelheid"
+      },
+      "thunderstorm_probability": {
+        "name": "Onweerskans"
+      },
+      "temp_change_24h": {
+        "name": "Temperatuurverandering (24u)"
+      },
+      "max_temp_24h": {
+        "name": "Maximumtemperatuur (24u)"
+      },
+      "min_temp_24h": {
+        "name": "Minimumtemperatuur (24u)"
+      },
+      "precipitation_24h": {
+        "name": "Neerslag (24u)"
+      },
+      "weather_condition": {
+        "name": "Weersomstandigheden"
+      }
+    },
+    "binary_sensor": {
+      "weather_alert": {
+        "name": "Weerwaarschuwing"
+      },
+      "severe_weather_alert": {
+        "name": "Ernstige weerwaarschuwing"
+      },
+      "urgent_weather_alert": {
+        "name": "Urgente weerwaarschuwing"
+      }
+    }
+  },
+  "services": {
+    "get_forecast": {
+      "name": "Voorspelling op aanvraag ophalen",
+      "description": "Haal weervoorspelling op aanvraag op, zelfs wanneer automatisch ophalen is uitgeschakeld. Deze service maakt een enkele API-aanroep om het gevraagde voorspellingstype op te halen.",
+      "fields": {
+        "entity_id": {
+          "name": "Entiteit-ID",
+          "description": "De weer-entiteit-ID waarvoor voorspellingen moeten worden opgehaald."
+        },
+        "forecast_type": {
+          "name": "Voorspellingstype",
+          "description": "Type voorspelling om op te halen (dagelijks of uurlijks)."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/google_weather/translations/pl.json
+++ b/custom_components/google_weather/translations/pl.json
@@ -1,0 +1,237 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Wprowadź klucz API",
+        "description": "Wprowadź swój klucz API Google Maps Platform. Upewnij się, że API pogody jest włączone w projekcie Google Cloud.",
+        "data": {
+          "api_key": "Klucz API"
+        },
+        "data_description": {
+          "api_key": "Twój klucz API Google Maps Platform z włączonym API pogody"
+        }
+      },
+      "location": {
+        "title": "Konfiguruj lokalizację",
+        "description": "Skonfiguruj lokalizację i ustawienia Google Weather. Lokalizacja domyślnie zostanie ustawiona na konfigurację Home Assistant.",
+        "data": {
+          "location": "Lokalizacja / Prefiks",
+          "latitude": "Szerokość geograficzna",
+          "longitude": "Długość geograficzna",
+          "unit_system": "System jednostek"
+        },
+        "data_description": {
+          "location": "Nazwa lokalizacji używana dla ID encji (domyślnie: 'home'). Przykłady: 'home', 'office', 'gw_home'",
+          "latitude": "Współrzędna szerokości geograficznej dla danych pogodowych (domyślnie: lokalizacja Home Assistant)",
+          "longitude": "Współrzędna długości geograficznej dla danych pogodowych (domyślnie: lokalizacja Home Assistant)",
+          "unit_system": "Wybierz metryczny (Celsjusz, km/h, mm) lub imperialny (Fahrenheit, mph, cale)"
+        }
+      },
+      "forecasts": {
+        "title": "Konfiguruj opcje prognozy",
+        "description": "Bieżące warunki i prognozy dzienne są zawsze uwzględniane. Wybierz poniżej dodatkowe funkcje.\n\nWyłącz funkcje, aby oszczędzać wywołania API. Alerty pogodowe są niedostępne w niektórych regionach.",
+        "data": {
+          "include_hourly_forecast": "Uwzględnij prognozy godzinowe",
+          "include_alerts": "Uwzględnij alerty pogodowe"
+        },
+        "data_description": {
+          "include_hourly_forecast": "Włącz prognozy pogody godzinowej",
+          "include_alerts": "Włącz alerty pogodowe (niedostępne w niektórych regionach)"
+        }
+      },
+      "intervals": {
+        "title": "Konfiguruj interwały aktualizacji",
+        "description": "Ustaw, jak często aktualizować każdy punkt końcowy w ciągu dnia i nocy. Google zapewnia łącznie 10 000 darmowych wywołań API/miesiąc. Wartości domyślne wykorzystują około 8 640 wywołań/miesiąc (13,6% poniżej limitu). Wszystkie interwały są w minutach.",
+        "data": {
+          "current_day_interval": "Bieżące warunki - Dzień (minuty)",
+          "current_night_interval": "Bieżące warunki - Noc (minuty)",
+          "daily_day_interval": "Prognoza dzienna - Dzień (minuty)",
+          "daily_night_interval": "Prognoza dzienna - Noc (minuty)",
+          "hourly_day_interval": "Prognoza godzinowa - Dzień (minuty)",
+          "hourly_night_interval": "Prognoza godzinowa - Noc (minuty)",
+          "alerts_day_interval": "Alerty pogodowe - Dzień (minuty)",
+          "alerts_night_interval": "Alerty pogodowe - Noc (minuty)",
+          "night_start": "Początek nocy (GG:MM)",
+          "night_end": "Koniec nocy (GG:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Jak często aktualizować bieżące warunki w ciągu dnia (domyślnie: 10 min)",
+          "current_night_interval": "Jak często aktualizować bieżące warunki w nocy (domyślnie: 30 min)",
+          "daily_day_interval": "Jak często aktualizować prognozę dzienną w ciągu dnia (domyślnie: 30 min)",
+          "daily_night_interval": "Jak często aktualizować prognozę dzienną w nocy (domyślnie: 60 min)",
+          "hourly_day_interval": "Jak często aktualizować prognozę godzinową w ciągu dnia (domyślnie: 20 min)",
+          "hourly_night_interval": "Jak często aktualizować prognozę godzinową w nocy (domyślnie: 60 min)",
+          "alerts_day_interval": "Jak często sprawdzać alerty pogodowe w ciągu dnia (domyślnie: 15 min)",
+          "alerts_night_interval": "Jak często sprawdzać alerty pogodowe w nocy (domyślnie: 30 min)",
+          "night_start": "Kiedy zaczyna się harmonogram nocnych aktualizacji (np. 22:00 dla 22)",
+          "night_end": "Kiedy kończy się harmonogram nocnych aktualizacji (np. 06:00 dla 6)"
+        }
+      },
+      "confirm": {
+        "title": "Potwierdź użycie API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_api_key": "Nieprawidłowy klucz API lub API pogody nie jest włączone. Sprawdź swoją konsolę Google Cloud.",
+      "cannot_connect": "Nie można połączyć się z Google Weather API. Sprawdź swoje połączenie sieciowe.",
+      "invalid_latitude": "Szerokość geograficzna musi być między -90 a 90",
+      "invalid_longitude": "Długość geograficzna musi być między -180 a 180"
+    },
+    "abort": {
+      "already_configured": "Ta lokalizacja jest już skonfigurowana"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Zaktualizuj lokalizację i opcje prognozy",
+        "description": "Zaktualizuj lokalizację i opcjonalne funkcje. Bieżące warunki i prognozy dzienne są zawsze uwzględniane.\n\nAlerty pogodowe są niedostępne w niektórych regionach.",
+        "data": {
+          "latitude": "Szerokość geograficzna",
+          "longitude": "Długość geograficzna",
+          "unit_system": "System jednostek",
+          "include_hourly_forecast": "Uwzględnij prognozy godzinowe",
+          "include_alerts": "Uwzględnij alerty pogodowe"
+        },
+        "data_description": {
+          "latitude": "Współrzędna szerokości geograficznej dla danych pogodowych",
+          "longitude": "Współrzędna długości geograficznej dla danych pogodowych",
+          "unit_system": "Wybierz metryczny (Celsjusz, km/h, mm) lub imperialny (Fahrenheit, mph, cale)",
+          "include_hourly_forecast": "Włącz prognozy pogody godzinowej",
+          "include_alerts": "Włącz alerty pogodowe (niedostępne w niektórych regionach)"
+        }
+      },
+      "intervals": {
+        "title": "Konfiguruj interwały aktualizacji",
+        "description": "Ustaw, jak często aktualizować każdy punkt końcowy w ciągu dnia i nocy. Google zapewnia łącznie 10 000 darmowych wywołań API/miesiąc. Wszystkie interwały są w minutach.",
+        "data": {
+          "current_day_interval": "Bieżące warunki - Dzień (minuty)",
+          "current_night_interval": "Bieżące warunki - Noc (minuty)",
+          "daily_day_interval": "Prognoza dzienna - Dzień (minuty)",
+          "daily_night_interval": "Prognoza dzienna - Noc (minuty)",
+          "hourly_day_interval": "Prognoza godzinowa - Dzień (minuty)",
+          "hourly_night_interval": "Prognoza godzinowa - Noc (minuty)",
+          "alerts_day_interval": "Alerty pogodowe - Dzień (minuty)",
+          "alerts_night_interval": "Alerty pogodowe - Noc (minuty)",
+          "night_start": "Początek nocy (GG:MM)",
+          "night_end": "Koniec nocy (GG:MM)"
+        },
+        "data_description": {
+          "current_day_interval": "Jak często aktualizować bieżące warunki w ciągu dnia (1-1440 minut)",
+          "current_night_interval": "Jak często aktualizować bieżące warunki w nocy (1-1440 minut)",
+          "daily_day_interval": "Jak często aktualizować prognozę dzienną w ciągu dnia (1-1440 minut)",
+          "daily_night_interval": "Jak często aktualizować prognozę dzienną w nocy (1-1440 minut)",
+          "hourly_day_interval": "Jak często aktualizować prognozę godzinową w ciągu dnia (1-1440 minut)",
+          "hourly_night_interval": "Jak często aktualizować prognozę godzinową w nocy (1-1440 minut)",
+          "alerts_day_interval": "Jak często sprawdzać alerty pogodowe w ciągu dnia (1-1440 minut)",
+          "alerts_night_interval": "Jak często sprawdzać alerty pogodowe w nocy (1-1440 minut)",
+          "night_start": "Kiedy zaczyna się harmonogram nocnych aktualizacji (np. 22:00)",
+          "night_end": "Kiedy kończy się harmonogram nocnych aktualizacji (np. 06:00)"
+        }
+      },
+      "confirm": {
+        "title": "Potwierdź użycie API",
+        "description": "{usage_summary}"
+      }
+    },
+    "error": {
+      "invalid_latitude": "Szerokość geograficzna musi być między -90 a 90",
+      "invalid_longitude": "Długość geograficzna musi być między -180 a 180"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "feels_like": {
+        "name": "Temperatura odczuwalna"
+      },
+      "dew_point": {
+        "name": "Punkt rosy"
+      },
+      "heat_index": {
+        "name": "Indeks ciepła"
+      },
+      "wind_chill": {
+        "name": "Temperatura odczuwalna wiatru"
+      },
+      "humidity": {
+        "name": "Wilgotność"
+      },
+      "pressure": {
+        "name": "Ciśnienie"
+      },
+      "wind_speed": {
+        "name": "Prędkość wiatru"
+      },
+      "wind_gust": {
+        "name": "Podmuchy wiatru"
+      },
+      "wind_direction": {
+        "name": "Kierunek wiatru"
+      },
+      "visibility": {
+        "name": "Widoczność"
+      },
+      "cloud_cover": {
+        "name": "Zachmurzenie"
+      },
+      "uv_index": {
+        "name": "Indeks UV"
+      },
+      "precipitation_probability": {
+        "name": "Prawdopodobieństwo opadów"
+      },
+      "precipitation_amount": {
+        "name": "Ilość opadów"
+      },
+      "thunderstorm_probability": {
+        "name": "Prawdopodobieństwo burzy"
+      },
+      "temp_change_24h": {
+        "name": "Zmiana temperatury (24h)"
+      },
+      "max_temp_24h": {
+        "name": "Temperatura maksymalna (24h)"
+      },
+      "min_temp_24h": {
+        "name": "Temperatura minimalna (24h)"
+      },
+      "precipitation_24h": {
+        "name": "Opady (24h)"
+      },
+      "weather_condition": {
+        "name": "Warunki pogodowe"
+      }
+    },
+    "binary_sensor": {
+      "weather_alert": {
+        "name": "Alert pogodowy"
+      },
+      "severe_weather_alert": {
+        "name": "Poważny alert pogodowy"
+      },
+      "urgent_weather_alert": {
+        "name": "Pilny alert pogodowy"
+      }
+    }
+  },
+  "services": {
+    "get_forecast": {
+      "name": "Pobierz prognozę na żądanie",
+      "description": "Pobierz prognozę pogody na żądanie, nawet gdy automatyczne odpytywanie jest wyłączone. Ta usługa wykonuje pojedyncze wywołanie API, aby pobrać żądany typ prognozy.",
+      "fields": {
+        "entity_id": {
+          "name": "ID encji",
+          "description": "ID encji pogody, dla której należy pobrać prognozy."
+        },
+        "forecast_type": {
+          "name": "Typ prognozy",
+          "description": "Typ prognozy do pobrania (dzienna lub godzinowa)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add complete translations for German, French, Dutch, Polish, and Spanish to improve accessibility for the largest non-English Home Assistant user bases. All translation files include:
- Configuration flow strings
- Options flow strings
- Entity names (sensors and binary sensors)
- Service descriptions
- Error messages

These translations cover the complete user interface for the Google Weather integration.