### PR TITLE
Fix daily forecast datetime format to ISO 8601 with timezone

### DIFF
--- a/custom_components/google_weather/weather.py
+++ b/custom_components/google_weather/weather.py
@@ -299,7 +299,16 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
 
             for day in daily_forecast:
                 display_date = day.get("displayDate", {})
-                datetime_str = f"{display_date.get('year')}-{display_date.get('month'):02d}-{display_date.get('day'):02d}"
+                # Create a naive datetime at midnight for the forecast day
+                naive_dt = datetime(
+                    display_date.get('year'),
+                    display_date.get('month'),
+                    display_date.get('day')
+                )
+                # Convert to timezone-aware datetime at start of day in local timezone
+                dt_aware = dt_util.start_of_local_day(naive_dt)
+                # Format as ISO 8601 string
+                datetime_str = dt_aware.isoformat()
 
                 daytime = day.get("daytimeForecast", {})
                 weather_condition = daytime.get("weatherCondition", {})


### PR DESCRIPTION
Previously, daily forecasts returned datetime as date-only strings (e.g., "2025-12-16"), while hourly forecasts returned full ISO 8601 format with timezone (e.g., "2025-12-16T14:00:00+00:00"). This inconsistency caused issues when users tried to parse both forecast types with the same datetime template format.

Now daily forecasts return timezone-aware ISO 8601 datetime strings at midnight local time, making them consistent with hourly forecasts and compatible with standard datetime parsing.