### PR TITLE
Fix API parameter name: use unitsSystem instead of units_system

### DIFF
--- a/custom_components/google_weather/coordinator.py
+++ b/custom_components/google_weather/coordinator.py
@@ -217,12 +217,12 @@ class GoogleWeatherCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> dict[str, Any]:
         """Fetch weather data from Google Weather API (runs in executor)."""
         try:
-            # Prepare common parameters for weather endpoints (with units_system)
+            # Prepare common parameters for weather endpoints (with unitsSystem)
             weather_params = {
                 "key": self.api_key,
                 "location.latitude": self.latitude,
                 "location.longitude": self.longitude,
-                "units_system": self.unit_system,
+                "unitsSystem": self.unit_system,
             }
 
             # Prepare parameters for alerts endpoint (without units_system)


### PR DESCRIPTION
The Google Weather API expects the parameter name to be 'unitsSystem' (camelCase), not 'units_system' (snake_case). This was causing the API to ignore the unit system selection and always default to METRIC.

This explains why:
- Setting integration to METRIC worked (API defaulted to metric anyway)
- Setting integration to IMPERIAL didn't work (API still returned metric, but sensors incorrectly labeled values as imperial)

With this fix, the API will now properly return data in the requested unit system (METRIC or IMPERIAL).

Fixes the root cause of imperial units not working correctly.