### PR TITLE
Added pageSize to daily forecast request

### DIFF
--- a/custom_components/google_weather/coordinator.py
+++ b/custom_components/google_weather/coordinator.py
@@ -251,7 +251,9 @@ class GoogleWeatherCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 daily_params = {
                     **weather_params,
                     "days": 10,  # Get 10 days of forecast
+                    "pageSize": 10,  # Get 10 days in single API request
                 }
+                
                 daily_response = requests.get(
                     f"{API_BASE_URL}/forecast/days:lookup",
                     params=daily_params,


### PR DESCRIPTION
Google API may only return 5 days per API request. Setting pageSize to 10 ensures all 10 forecast days are received in a single request.

Tested and verified in Home Assistant.