### PR TITLE
fix: auto-detect unit system

### DIFF
--- a/custom_components/google_weather/binary_sensor.py
+++ b/custom_components/google_weather/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ALERT_SENSOR_KEYS, CONF_INCLUDE_ALERTS, CONF_LOCATION, DEFAULT_INCLUDE_ALERTS, DOMAIN
+from .const import ALERT_SENSOR_KEYS, CONF_INCLUDE_ALERTS, CONF_LOCATION, DEFAULT_INCLUDE_ALERTS, DOMAIN, VERSION
 from .coordinator import GoogleWeatherCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -247,7 +247,7 @@ class GoogleWeatherBinarySensor(
             "name": f"{location_name} Binary Sensors",
             "manufacturer": "Google",
             "model": "Weather API - Binary Sensors",
-            "sw_version": "1.1.10",
+            "sw_version": VERSION,
             "via_device": (DOMAIN, entry.entry_id),
         }
 

--- a/custom_components/google_weather/config_flow.py
+++ b/custom_components/google_weather/config_flow.py
@@ -11,8 +11,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.util.unit_system import METRIC_SYSTEM
-
 from .const import (
     CONF_ALERTS_DAY_INTERVAL,
     CONF_ALERTS_NIGHT_INTERVAL,
@@ -29,7 +27,6 @@ from .const import (
     CONF_LOCATION,
     CONF_NIGHT_END,
     CONF_NIGHT_START,
-    CONF_UNIT_SYSTEM,
     DEFAULT_ALERTS_DAY_INTERVAL,
     DEFAULT_ALERTS_NIGHT_INTERVAL,
     DEFAULT_CURRENT_DAY_INTERVAL,
@@ -43,12 +40,8 @@ from .const import (
     DEFAULT_INCLUDE_HOURLY_FORECAST,
     DEFAULT_NIGHT_END,
     DEFAULT_NIGHT_START,
-    DEFAULT_UNIT_SYSTEM,
     DOMAIN,
     API_BASE_URL,
-    UNIT_SYSTEMS,
-    UNIT_SYSTEM_METRIC,
-    UNIT_SYSTEM_IMPERIAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -226,7 +219,6 @@ class GoogleWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_LOCATION: user_input[CONF_LOCATION],
                     CONF_LATITUDE: latitude,
                     CONF_LONGITUDE: longitude,
-                    CONF_UNIT_SYSTEM: user_input[CONF_UNIT_SYSTEM],
                 }
                 return await self.async_step_forecasts()
 
@@ -235,10 +227,6 @@ class GoogleWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         default_longitude = self.hass.config.longitude
         default_location_name = self.hass.config.location_name or "home"
 
-        # Determine default unit system from Home Assistant configuration
-        # Use instance check (is_metric is deprecated since HA 2022.11)
-        default_unit_system = UNIT_SYSTEM_METRIC if self.hass.config.units is METRIC_SYSTEM else UNIT_SYSTEM_IMPERIAL
-
         return self.async_show_form(
             step_id="location",
             data_schema=vol.Schema(
@@ -246,7 +234,6 @@ class GoogleWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_LOCATION, default=default_location_name): str,
                     vol.Required(CONF_LATITUDE, default=default_latitude): vol.Coerce(float),
                     vol.Required(CONF_LONGITUDE, default=default_longitude): vol.Coerce(float),
-                    vol.Required(CONF_UNIT_SYSTEM, default=default_unit_system): vol.In(UNIT_SYSTEMS),
                 }
             ),
             errors=errors,
@@ -427,7 +414,6 @@ class GoogleWeatherOptionsFlow(config_entries.OptionsFlow):
                 self.location_data = {
                     CONF_LATITUDE: latitude,
                     CONF_LONGITUDE: longitude,
-                    CONF_UNIT_SYSTEM: user_input[CONF_UNIT_SYSTEM],
                 }
                 # Daily forecasts are always enabled (not configurable)
                 self.forecast_options = {
@@ -447,10 +433,6 @@ class GoogleWeatherOptionsFlow(config_entries.OptionsFlow):
                 CONF_LONGITUDE,
                 default=current_data.get(CONF_LONGITUDE),
             ): vol.Coerce(float),
-            vol.Required(
-                CONF_UNIT_SYSTEM,
-                default=current_data.get(CONF_UNIT_SYSTEM, DEFAULT_UNIT_SYSTEM),
-            ): vol.In(UNIT_SYSTEMS),
             # Hourly forecast checkbox
             vol.Optional(
                 CONF_INCLUDE_HOURLY_FORECAST,

--- a/custom_components/google_weather/const.py
+++ b/custom_components/google_weather/const.py
@@ -1,15 +1,13 @@
 """Constants for the Google Weather integration."""
-from datetime import timedelta
 
 DOMAIN = "google_weather"
+VERSION = "1.1.11"
 
 # Configuration
 CONF_API_KEY = "api_key"
 CONF_LOCATION = "location"
 CONF_LATITUDE = "latitude"
 CONF_LONGITUDE = "longitude"
-CONF_UNIT_SYSTEM = "unit_system"
-
 # Update interval configuration
 CONF_CURRENT_DAY_INTERVAL = "current_day_interval"
 CONF_CURRENT_NIGHT_INTERVAL = "current_night_interval"
@@ -26,7 +24,6 @@ CONF_INCLUDE_HOURLY_FORECAST = "include_hourly_forecast"
 CONF_INCLUDE_ALERTS = "include_alerts"
 
 # Defaults
-DEFAULT_UNIT_SYSTEM = "METRIC"
 
 # Default update intervals (in minutes) - optimized for 10,000 free API calls/month
 # Nighttime is 8 hours (22:00-06:00), daytime is 16 hours (06:00-22:00)
@@ -65,7 +62,6 @@ DEFAULT_INCLUDE_ALERTS = True
 # Unit systems
 UNIT_SYSTEM_METRIC = "METRIC"
 UNIT_SYSTEM_IMPERIAL = "IMPERIAL"
-UNIT_SYSTEMS = [UNIT_SYSTEM_METRIC, UNIT_SYSTEM_IMPERIAL]
 
 # API
 API_BASE_URL = "https://weather.googleapis.com/v1"

--- a/custom_components/google_weather/coordinator.py
+++ b/custom_components/google_weather/coordinator.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import (
     API_BASE_URL,
@@ -28,7 +29,6 @@ from .const import (
     CONF_INCLUDE_HOURLY_FORECAST,
     CONF_NIGHT_END,
     CONF_NIGHT_START,
-    CONF_UNIT_SYSTEM,
     DEFAULT_ALERTS_DAY_INTERVAL,
     DEFAULT_ALERTS_NIGHT_INTERVAL,
     DEFAULT_CURRENT_DAY_INTERVAL,
@@ -42,12 +42,13 @@ from .const import (
     DEFAULT_INCLUDE_HOURLY_FORECAST,
     DEFAULT_NIGHT_END,
     DEFAULT_NIGHT_START,
-    DEFAULT_UNIT_SYSTEM,
     DOMAIN,
     ENDPOINT_ALERTS,
     ENDPOINT_CURRENT,
     ENDPOINT_DAILY,
     ENDPOINT_HOURLY,
+    UNIT_SYSTEM_IMPERIAL,
+    UNIT_SYSTEM_METRIC,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -160,7 +161,9 @@ class GoogleWeatherCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api_key = entry.data.get(CONF_API_KEY)
         self.latitude = current_data.get(CONF_LATITUDE)
         self.longitude = current_data.get(CONF_LONGITUDE)
-        self.unit_system = current_data.get(CONF_UNIT_SYSTEM, DEFAULT_UNIT_SYSTEM)
+
+        # Auto-detect unit system from Home Assistant's configuration
+        self.unit_system = UNIT_SYSTEM_METRIC if hass.config.units is METRIC_SYSTEM else UNIT_SYSTEM_IMPERIAL
 
         # Get forecast/alerts inclusion settings
         self.include_daily_forecast = current_data.get(CONF_INCLUDE_DAILY_FORECAST, DEFAULT_INCLUDE_DAILY_FORECAST)

--- a/custom_components/google_weather/manifest.json
+++ b/custom_components/google_weather/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "requests>=2.31.0"
   ],
-  "version": "1.1.10"
+  "version": "1.1.11"
 }

--- a/custom_components/google_weather/sensor.py
+++ b/custom_components/google_weather/sensor.py
@@ -29,10 +29,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     CONF_INCLUDE_HOURLY_FORECAST,
     CONF_LOCATION,
-    CONF_UNIT_SYSTEM,
     DEFAULT_INCLUDE_HOURLY_FORECAST,
     DOMAIN,
     UNIT_SYSTEM_IMPERIAL,
+    VERSION,
 )
 from .coordinator import GoogleWeatherCoordinator
 
@@ -387,12 +387,12 @@ class GoogleWeatherSensor(CoordinatorEntity[GoogleWeatherCoordinator], SensorEnt
             "name": f"{location_name} Observational Sensors",
             "manufacturer": "Google",
             "model": "Weather API - Sensors",
-            "sw_version": "1.1.10",
+            "sw_version": VERSION,
             "via_device": (DOMAIN, entry.entry_id),
         }
 
-        # Store unit system for property override
-        self._unit_system = entry.options.get(CONF_UNIT_SYSTEM) or entry.data.get(CONF_UNIT_SYSTEM, "METRIC")
+        # Read unit system from coordinator (auto-detected from HA config)
+        self._unit_system = coordinator.unit_system
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/custom_components/google_weather/strings.json
+++ b/custom_components/google_weather/strings.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Location / Prefix",
           "latitude": "Latitude",
-          "longitude": "Longitude",
-          "unit_system": "Unit System"
+          "longitude": "Longitude"
         },
         "data_description": {
           "location": "Location name used for entity IDs (default: 'home'). Examples: 'home', 'office', 'gw_home'",
           "latitude": "Latitude coordinate for weather data (defaults to Home Assistant location)",
-          "longitude": "Longitude coordinate for weather data (defaults to Home Assistant location)",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)"
+          "longitude": "Longitude coordinate for weather data (defaults to Home Assistant location)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Latitude",
           "longitude": "Longitude",
-          "unit_system": "Unit System",
           "include_hourly_forecast": "Include Hourly Forecasts",
           "include_alerts": "Include Weather Alerts"
         },
         "data_description": {
           "latitude": "Latitude coordinate for weather data",
           "longitude": "Longitude coordinate for weather data",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
           "include_hourly_forecast": "Enable hourly weather forecasts",
           "include_alerts": "Enable weather alerts (unavailable in some regions)"
         }

--- a/custom_components/google_weather/translations/de.json
+++ b/custom_components/google_weather/translations/de.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Standort / Präfix",
           "latitude": "Breitengrad",
-          "longitude": "Längengrad",
-          "unit_system": "Einheitensystem"
+          "longitude": "Längengrad"
         },
         "data_description": {
           "location": "Standortname für Entitäts-IDs (Standard: 'home'). Beispiele: 'home', 'office', 'gw_home'",
           "latitude": "Breitengradkoordinate für Wetterdaten (Standard: Home Assistant-Standort)",
-          "longitude": "Längengradkoordinate für Wetterdaten (Standard: Home Assistant-Standort)",
-          "unit_system": "Wählen Sie metrisch (Celsius, km/h, mm) oder imperial (Fahrenheit, mph, Zoll)"
+          "longitude": "Längengradkoordinate für Wetterdaten (Standard: Home Assistant-Standort)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Breitengrad",
           "longitude": "Längengrad",
-          "unit_system": "Einheitensystem",
           "include_hourly_forecast": "Stündliche Vorhersagen einbeziehen",
           "include_alerts": "Wetterwarnungen einbeziehen"
         },
         "data_description": {
           "latitude": "Breitengradkoordinate für Wetterdaten",
           "longitude": "Längengradkoordinate für Wetterdaten",
-          "unit_system": "Wählen Sie metrisch (Celsius, km/h, mm) oder imperial (Fahrenheit, mph, Zoll)",
           "include_hourly_forecast": "Stündliche Wettervorhersagen aktivieren",
           "include_alerts": "Wetterwarnungen aktivieren (in einigen Regionen nicht verfügbar)"
         }

--- a/custom_components/google_weather/translations/en.json
+++ b/custom_components/google_weather/translations/en.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Location / Prefix",
           "latitude": "Latitude",
-          "longitude": "Longitude",
-          "unit_system": "Unit System"
+          "longitude": "Longitude"
         },
         "data_description": {
           "location": "Location name used for entity IDs (default: 'home'). Examples: 'home', 'office', 'gw_home'",
           "latitude": "Latitude coordinate for weather data (defaults to Home Assistant location)",
-          "longitude": "Longitude coordinate for weather data (defaults to Home Assistant location)",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)"
+          "longitude": "Longitude coordinate for weather data (defaults to Home Assistant location)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Latitude",
           "longitude": "Longitude",
-          "unit_system": "Unit System",
           "include_hourly_forecast": "Include Hourly Forecasts",
           "include_alerts": "Include Weather Alerts"
         },
         "data_description": {
           "latitude": "Latitude coordinate for weather data",
           "longitude": "Longitude coordinate for weather data",
-          "unit_system": "Choose metric (Celsius, km/h, mm) or imperial (Fahrenheit, mph, inches)",
           "include_hourly_forecast": "Enable hourly weather forecasts",
           "include_alerts": "Enable weather alerts (unavailable in some regions)"
         }

--- a/custom_components/google_weather/translations/es.json
+++ b/custom_components/google_weather/translations/es.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Ubicación / Prefijo",
           "latitude": "Latitud",
-          "longitude": "Longitud",
-          "unit_system": "Sistema de unidades"
+          "longitude": "Longitud"
         },
         "data_description": {
           "location": "Nombre de ubicación usado para IDs de entidad (predeterminado: 'home'). Ejemplos: 'home', 'office', 'gw_home'",
           "latitude": "Coordenada de latitud para datos meteorológicos (predeterminado: ubicación de Home Assistant)",
-          "longitude": "Coordenada de longitud para datos meteorológicos (predeterminado: ubicación de Home Assistant)",
-          "unit_system": "Elija métrico (Celsius, km/h, mm) o imperial (Fahrenheit, mph, pulgadas)"
+          "longitude": "Coordenada de longitud para datos meteorológicos (predeterminado: ubicación de Home Assistant)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Latitud",
           "longitude": "Longitud",
-          "unit_system": "Sistema de unidades",
           "include_hourly_forecast": "Incluir pronósticos por hora",
           "include_alerts": "Incluir alertas meteorológicas"
         },
         "data_description": {
           "latitude": "Coordenada de latitud para datos meteorológicos",
           "longitude": "Coordenada de longitud para datos meteorológicos",
-          "unit_system": "Elija métrico (Celsius, km/h, mm) o imperial (Fahrenheit, mph, pulgadas)",
           "include_hourly_forecast": "Habilitar pronósticos meteorológicos por hora",
           "include_alerts": "Habilitar alertas meteorológicas (no disponibles en algunas regiones)"
         }

--- a/custom_components/google_weather/translations/fr.json
+++ b/custom_components/google_weather/translations/fr.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Emplacement / Préfixe",
           "latitude": "Latitude",
-          "longitude": "Longitude",
-          "unit_system": "Système d'unités"
+          "longitude": "Longitude"
         },
         "data_description": {
           "location": "Nom de l'emplacement utilisé pour les ID d'entité (par défaut : 'home'). Exemples : 'home', 'office', 'gw_home'",
           "latitude": "Coordonnée de latitude pour les données météo (par défaut : emplacement Home Assistant)",
-          "longitude": "Coordonnée de longitude pour les données météo (par défaut : emplacement Home Assistant)",
-          "unit_system": "Choisissez métrique (Celsius, km/h, mm) ou impérial (Fahrenheit, mph, pouces)"
+          "longitude": "Coordonnée de longitude pour les données météo (par défaut : emplacement Home Assistant)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Latitude",
           "longitude": "Longitude",
-          "unit_system": "Système d'unités",
           "include_hourly_forecast": "Inclure les prévisions horaires",
           "include_alerts": "Inclure les alertes météo"
         },
         "data_description": {
           "latitude": "Coordonnée de latitude pour les données météo",
           "longitude": "Coordonnée de longitude pour les données météo",
-          "unit_system": "Choisissez métrique (Celsius, km/h, mm) ou impérial (Fahrenheit, mph, pouces)",
           "include_hourly_forecast": "Activer les prévisions météo horaires",
           "include_alerts": "Activer les alertes météo (non disponibles dans certaines régions)"
         }

--- a/custom_components/google_weather/translations/nl.json
+++ b/custom_components/google_weather/translations/nl.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Locatie / Voorvoegsel",
           "latitude": "Breedtegraad",
-          "longitude": "Lengtegraad",
-          "unit_system": "Eenheidssysteem"
+          "longitude": "Lengtegraad"
         },
         "data_description": {
           "location": "Locatienaam gebruikt voor entiteit-ID's (standaard: 'home'). Voorbeelden: 'home', 'office', 'gw_home'",
           "latitude": "Breedtegraadcoördinaat voor weergegevens (standaard: Home Assistant-locatie)",
-          "longitude": "Lengtegraadcoördinaat voor weergegevens (standaard: Home Assistant-locatie)",
-          "unit_system": "Kies metrisch (Celsius, km/u, mm) of imperiaal (Fahrenheit, mph, inches)"
+          "longitude": "Lengtegraadcoördinaat voor weergegevens (standaard: Home Assistant-locatie)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Breedtegraad",
           "longitude": "Lengtegraad",
-          "unit_system": "Eenheidssysteem",
           "include_hourly_forecast": "Uurlijkse voorspellingen opnemen",
           "include_alerts": "Weerwaarschuwingen opnemen"
         },
         "data_description": {
           "latitude": "Breedtegraadcoördinaat voor weergegevens",
           "longitude": "Lengtegraadcoördinaat voor weergegevens",
-          "unit_system": "Kies metrisch (Celsius, km/u, mm) of imperiaal (Fahrenheit, mph, inches)",
           "include_hourly_forecast": "Schakel uurlijkse weervoorspellingen in",
           "include_alerts": "Schakel weerwaarschuwingen in (niet beschikbaar in sommige regio's)"
         }

--- a/custom_components/google_weather/translations/pl.json
+++ b/custom_components/google_weather/translations/pl.json
@@ -17,14 +17,12 @@
         "data": {
           "location": "Lokalizacja / Prefiks",
           "latitude": "Szerokość geograficzna",
-          "longitude": "Długość geograficzna",
-          "unit_system": "System jednostek"
+          "longitude": "Długość geograficzna"
         },
         "data_description": {
           "location": "Nazwa lokalizacji używana dla ID encji (domyślnie: 'home'). Przykłady: 'home', 'office', 'gw_home'",
           "latitude": "Współrzędna szerokości geograficznej dla danych pogodowych (domyślnie: lokalizacja Home Assistant)",
-          "longitude": "Współrzędna długości geograficznej dla danych pogodowych (domyślnie: lokalizacja Home Assistant)",
-          "unit_system": "Wybierz metryczny (Celsjusz, km/h, mm) lub imperialny (Fahrenheit, mph, cale)"
+          "longitude": "Współrzędna długości geograficznej dla danych pogodowych (domyślnie: lokalizacja Home Assistant)"
         }
       },
       "forecasts": {
@@ -90,14 +88,12 @@
         "data": {
           "latitude": "Szerokość geograficzna",
           "longitude": "Długość geograficzna",
-          "unit_system": "System jednostek",
           "include_hourly_forecast": "Uwzględnij prognozy godzinowe",
           "include_alerts": "Uwzględnij alerty pogodowe"
         },
         "data_description": {
           "latitude": "Współrzędna szerokości geograficznej dla danych pogodowych",
           "longitude": "Współrzędna długości geograficznej dla danych pogodowych",
-          "unit_system": "Wybierz metryczny (Celsjusz, km/h, mm) lub imperialny (Fahrenheit, mph, cale)",
           "include_hourly_forecast": "Włącz prognozy pogody godzinowej",
           "include_alerts": "Włącz alerty pogodowe (niedostępne w niektórych regionach)"
         }

--- a/custom_components/google_weather/weather.py
+++ b/custom_components/google_weather/weather.py
@@ -24,14 +24,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    CONF_INCLUDE_DAILY_FORECAST,
     CONF_INCLUDE_HOURLY_FORECAST,
     CONF_LOCATION,
-    CONF_UNIT_SYSTEM,
-    DEFAULT_INCLUDE_DAILY_FORECAST,
     DEFAULT_INCLUDE_HOURLY_FORECAST,
     DOMAIN,
     UNIT_SYSTEM_IMPERIAL,
+    VERSION,
 )
 from .coordinator import GoogleWeatherCoordinator
 
@@ -121,11 +119,11 @@ class GoogleWeatherEntity(CoordinatorEntity[GoogleWeatherCoordinator], WeatherEn
             "name": f"{location_name} Weather",
             "manufacturer": "Google",
             "model": "Weather API",
-            "sw_version": "1.1.10",
+            "sw_version": VERSION,
         }
 
         # Set units based on unit system - API returns values in the requested unit system
-        unit_system = entry.options.get(CONF_UNIT_SYSTEM) or entry.data.get(CONF_UNIT_SYSTEM, "METRIC")
+        unit_system = coordinator.unit_system
         if unit_system == UNIT_SYSTEM_IMPERIAL:
             self._attr_native_temperature_unit = UnitOfTemperature.FAHRENHEIT
             self._attr_native_pressure_unit = UnitOfPressure.MBAR  # API does not convert pressure


### PR DESCRIPTION
The integration's unit system dropdown had no effect on displayed values because HA always converts to its own system-wide preference. Removed the selector and auto-detect from hass.config.units so the API returns data in the user's expected units.

Closes #65