### PR TITLE
fix: stop polling alerts where they are unsupported

### DIFF
--- a/custom_components/google_weather/const.py
+++ b/custom_components/google_weather/const.py
@@ -74,3 +74,9 @@ ENDPOINT_ALERTS = "alerts"
 
 # Alert sensor keys (used in binary_sensor.py and __init__.py)
 ALERT_SENSOR_KEYS = frozenset({"weather_alert", "severe_weather_alert", "urgent_weather_alert"})
+
+# How long to leave between requests once a location has answered 404 for
+# alerts. Google adds alert coverage over time, so support is re-checked rather
+# than treated as permanent, but at a rate that costs ~30 calls a month instead
+# of the ~2,400 the configured intervals would spend on a 404.
+ALERTS_UNSUPPORTED_RETRY_MINUTES = 1440  # once a day

--- a/custom_components/google_weather/coordinator.py
+++ b/custom_components/google_weather/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .conditions import SNOW_CONDITION_TYPES
 from .const import (
+    ALERTS_UNSUPPORTED_RETRY_MINUTES,
     API_BASE_URL,
     CONF_ALERTS_DAY_INTERVAL,
     CONF_ALERTS_NIGHT_INTERVAL,
@@ -238,6 +239,13 @@ class GoogleWeatherCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         is_night = self._is_night_time()
         interval_minutes = self.intervals[endpoint]["night" if is_night else "day"]
 
+        # A location outside Google's alert coverage answers 404 to every
+        # request, so polling it at the configured interval spends calls on a
+        # response that can never carry an alert. Back off to a daily probe
+        # instead of giving up, since coverage does get added over time.
+        if endpoint == ENDPOINT_ALERTS and self.alerts_supported is False:
+            interval_minutes = max(interval_minutes, ALERTS_UNSUPPORTED_RETRY_MINUTES)
+
         # Check if enough time has passed
         time_since_update = (dt_util.now() - last_update).total_seconds() / 60
         return time_since_update >= interval_minutes
@@ -382,20 +390,25 @@ class GoogleWeatherCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     alerts_response.raise_for_status()
                     alerts_data = alerts_response.json()
                     updated_data["alerts"] = alerts_data.get("weatherAlerts", [])
-                    # Mark alerts as supported for this location
-                    if self.alerts_supported is None:
+                    # Mark alerts as supported for this location. This also
+                    # covers a location that starts answering after previously
+                    # returning 404; the alert entities are created at platform
+                    # setup, so they appear on the next reload or restart.
+                    if self.alerts_supported is not True:
                         self.alerts_supported = True
                         _LOGGER.info("Weather alerts are supported for this location")
                 except requests.HTTPError as err:
                     # Handle 404 errors gracefully - region doesn't support alerts
                     if err.response.status_code == 404:
-                        # Mark alerts as not supported for this location
-                        if self.alerts_supported is None:
+                        # Mark alerts as not supported for this location, which
+                        # also drops the endpoint back to a daily probe.
+                        if self.alerts_supported is not False:
                             self.alerts_supported = False
                             _LOGGER.info(
                                 "Weather alerts not available for this location (HTTP 404). "
                                 "This is normal for regions without alert coverage. "
-                                "Warning sensors will not be created."
+                                "Warning sensors will not be created, and the endpoint "
+                                "will only be re-checked once a day."
                             )
                         updated_data["alerts"] = []
                     else:


### PR DESCRIPTION
Weather alerts are unavailable in many regions, and Google answers 404 there. The integration already detected this and skipped creating the alert entities, but it kept requesting the endpoint at the configured interval — roughly 2,400 calls a month at the defaults, or a quarter of the free tier, spent on a response that can never contain an alert. Affected users had no way to notice short of reading debug logs.

Once a 404 is seen, the endpoint now drops to a single daily probe. That is about 30 calls a month instead of 2,400, and it keeps checking rather than giving up, so a region that gains alert coverage starts working.

The supported flag was also only ever written when it was still unset, which made it effectively write-once: a location that later gained coverage would have stayed marked unsupported for the life of the config entry. Both transitions now take effect. The alert entities are created at platform setup, so they appear after the next reload rather than immediately.

No configuration change. Users in regions that do have alert coverage are unaffected.
